### PR TITLE
Scout DivideByZero Exception Fix

### DIFF
--- a/Assets/Scripts/Entities/Army.cs
+++ b/Assets/Scripts/Entities/Army.cs
@@ -206,7 +206,7 @@ public class Army
                 if ((int)SCooldownOffset > 0f)
                     return ((int)SCooldownOffset);
                 else
-                    return 0;
+                    return 1;
             }
             return (Config.ArmyMP + Config.ScoutMP) + (int)(Config.ArmyMP * MPMod);
         }
@@ -216,7 +216,7 @@ public class Army
            if (-1f > MPMod)
                 return 0;
            if (SCooldown > (Config.ArmyMP + (int)(Config.ArmyMP * MPMod)))
-                return 0;
+                return 1;
             return Config.ArmyMP + (int)(Config.ArmyMP * MPMod) - (int)SCooldown;
         }
     }

--- a/Assets/Scripts/Utility/Texts/DefaultTooltips.cs
+++ b/Assets/Scripts/Utility/Texts/DefaultTooltips.cs
@@ -705,7 +705,7 @@ Does not retroactively affect already created units.";
             case 283:
                 return "Replaces scat with diapers for absorbed units and diaper-related tactical log messages will be displayed.";
             case 284:
-                return "Controls how many bonus movement points scout sized armies start with every turn. When scouts use their bonus MP they will have decreased MP by the amount uesd the following turn";
+                return "Controls how many bonus movement points scout sized armies start with every turn. When scouts use their bonus MP they will have decreased MP by the amount uesd the following turn down to a minimum of 1 MP";
             case 285:
                 return "Determines the maximum amount of units allowed to be in a scout army(Set to 0 to disable feature).";
             case 286:


### PR DESCRIPTION
Scouts are now capped of a minimum MP of 1 (instead of 0) when suffering their MP penalty/cooldown