### PR TITLE
Auto surrender full heal(goddess'mercy)

### DIFF
--- a/Assets/Scripts/AI/Monsters/MonsterStrategicAI.cs
+++ b/Assets/Scripts/AI/Monsters/MonsterStrategicAI.cs
@@ -345,6 +345,8 @@ class MonsterStrategicAI : IStrategicAI
                 return;
             }
         }
+        if(Config.MonsterMPBonus == false && army.RemainingMP > Config.ArmyMP)
+            army.RemainingMP = Config.ArmyMP;
         if(Config.NightMoveMonsters && !State.World.IsNight && Config.DayNightEnabled) //DayNight Modification (zero's out monster AP when NOT night)
         {
             army.RemainingMP = 0;

--- a/Assets/Scripts/Core/Config.cs
+++ b/Assets/Scripts/Core/Config.cs
@@ -163,6 +163,7 @@ static class Config
     internal static FeedingType FeedingType => World.FeedingType;
     internal static FourthWallBreakType FourthWallBreakType => World.FourthWallBreakType;
     internal static UBConversion UBConversion => World.UBConversion;
+    internal static GoddessMercy GoddessMercy => World.GoddessMercy;
     internal static SucklingPermission SucklingPermission => World.SucklingPermission;
 
     internal static int StartingPopulation => World.StartingPopulation;

--- a/Assets/Scripts/Core/Config.cs
+++ b/Assets/Scripts/Core/Config.cs
@@ -308,6 +308,7 @@ static class Config
     internal static float NightChanceIncrease => World.NightChanceIncrease;
     internal static bool NightMonsters => World.GetValue("NightMonsters");
     internal static bool NightMoveMonsters => World.GetValue("NightMoveMonsters");
+    internal static bool MonsterMPBonus => World.GetValue("MonsterMPBonus");
     internal static int DefualtTacticalSightRange => World.DefualtTacticalSightRange;
     internal static int NightStrategicSightReduction => World.NightStrategicSightReduction;
     internal static int RevealTurn => World.RevealTurn;

--- a/Assets/Scripts/Core/WorldConfig.cs
+++ b/Assets/Scripts/Core/WorldConfig.cs
@@ -384,6 +384,7 @@ public class WorldConfig
             ["DayNightRandom"] = true,
             ["NightMonsters"] = false,
             ["NightMoveMonsters"] = false,
+            ["MonsterMPBonus"] = false,
             ["CombatComplicationsEnabled"] = false,
             ["StatCrit"] = false,
             ["StatGraze"] = false,

--- a/Assets/Scripts/Core/WorldConfig.cs
+++ b/Assets/Scripts/Core/WorldConfig.cs
@@ -148,6 +148,8 @@ public class WorldConfig
     [OdinSerialize]
     internal UBConversion UBConversion = 0;
     [OdinSerialize]
+    internal GoddessMercy GoddessMercy = 0;
+    [OdinSerialize]
     internal SucklingPermission SucklingPermission = 0;
 
     [OdinSerialize]

--- a/Assets/Scripts/Entities/Units/Actor_Unit.cs
+++ b/Assets/Scripts/Entities/Units/Actor_Unit.cs
@@ -2287,7 +2287,22 @@ public class Actor_Unit
                     State.GameManager.TacticalMode.SwitchAlignment(this);
                     AIAvoidEat = 2;
                     State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{Unit.Name} switched sides when they surrendered");
+                    if ((Config.GoddessMercy == GoddessMercy.Both) || (Config.GoddessMercy == GoddessMercy.DefectorOnly))
+                    {
+                        Unit.Health = Unit.MaxHealth;
+                        State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"A light shines from above on {Unit.Name}");
+                    }
                 }
+                else if ((Config.GoddessMercy == GoddessMercy.Both) || (Config.GoddessMercy == GoddessMercy.LoyalOnly))
+                {
+                    Unit.Health = Unit.MaxHealth;
+                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"A light shines from above on {Unit.Name} for their loyalty");
+                }
+            }
+            else if ((Config.GoddessMercy == GoddessMercy.Both) || (Config.GoddessMercy == GoddessMercy.LoyalOnly))
+            {
+                Unit.Health = Unit.MaxHealth;
+                State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"A light shines from above on {Unit.Name} for their loyalty");
             }
             if (State.Rand.NextDouble() <= Config.SurrenderedPredAutoRegur)
             {

--- a/Assets/Scripts/Enums/GoddessMercy.cs
+++ b/Assets/Scripts/Enums/GoddessMercy.cs
@@ -1,0 +1,7 @@
+public enum GoddessMercy
+{
+    Both,
+    DefectorOnly,
+    LoyalOnly,
+    Disabled,
+}

--- a/Assets/Scripts/Enums/GoddessMercy.cs.meta
+++ b/Assets/Scripts/Enums/GoddessMercy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f77ba79915681dd4387f4df7c73ce08a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Subwindows/ContentSettings.cs
+++ b/Assets/Scripts/Subwindows/ContentSettings.cs
@@ -129,6 +129,7 @@ public class ContentSettings : MonoBehaviour
     public TMP_Dropdown FeedingType;
     public TMP_Dropdown FourthWallBreakType;
     public TMP_Dropdown UBConversion;
+    public TMP_Dropdown GoddessMercy;
     public TMP_Dropdown SucklingPermission;
     public TMP_Dropdown WinterStuff;
 
@@ -779,6 +780,7 @@ public class ContentSettings : MonoBehaviour
         Config.World.FeedingType = (FeedingType)PlayerPrefs.GetInt("FeedingType", 0);
         Config.World.FourthWallBreakType = (FourthWallBreakType)PlayerPrefs.GetInt("FourthWallBreakType", 0);
         Config.World.UBConversion = (UBConversion)PlayerPrefs.GetInt("UBConversion", 0);
+        Config.World.GoddessMercy = (GoddessMercy)PlayerPrefs.GetInt("GoddessMercy", 0);
         Config.World.SucklingPermission = (SucklingPermission)PlayerPrefs.GetInt("SucklingPermission", 0);
         Config.World.EscapeRate = PlayerPrefs.GetInt("EscapeRate", 0);
         Config.World.RandomEventRate = PlayerPrefs.GetInt("RandomEventRate", 0);
@@ -959,6 +961,7 @@ public class ContentSettings : MonoBehaviour
         FeedingType.value = (int)Config.FeedingType;
         FourthWallBreakType.value = (int)Config.FourthWallBreakType;
         UBConversion.value = (int)Config.UBConversion;
+        GoddessMercy.value = (int)Config.GoddessMercy;
         SucklingPermission.value = (int)Config.SucklingPermission;
         WinterStuff.value = (int)Config.World.WinterStuff;
         DiplomacyScale.value = (int)Config.DiplomacyScale;
@@ -975,6 +978,7 @@ public class ContentSettings : MonoBehaviour
         FeedingType.RefreshShownValue();
         FourthWallBreakType.RefreshShownValue();
         UBConversion.RefreshShownValue();
+        GoddessMercy.RefreshShownValue();
         SucklingPermission.RefreshShownValue();
         DiplomacyScale.RefreshShownValue();
         MaxSpellLevelDrop.RefreshShownValue();
@@ -1169,6 +1173,7 @@ public class ContentSettings : MonoBehaviour
         Config.World.FourthWallBreakType = (FourthWallBreakType)FourthWallBreakType.value;
         Config.World.FeedingType = (FeedingType)FeedingType.value;
         Config.World.UBConversion = (UBConversion)UBConversion.value;
+        Config.World.GoddessMercy = (GoddessMercy)GoddessMercy.value;
         Config.World.SucklingPermission = (SucklingPermission)SucklingPermission.value;
         Config.World.WinterStuff = (Config.SeasonalType)WinterStuff.value;
         Config.World.DiplomacyScale = (DiplomacyScale)DiplomacyScale.value;
@@ -1372,6 +1377,7 @@ public class ContentSettings : MonoBehaviour
         PlayerPrefs.SetInt("FeedingType", FeedingType.value);
         PlayerPrefs.SetInt("FourthWallBreakType", FourthWallBreakType.value);
         PlayerPrefs.SetInt("UBConversion", UBConversion.value);
+        PlayerPrefs.SetInt("GoddessMercy", GoddessMercy.value);
         PlayerPrefs.SetInt("SucklingPermission", SucklingPermission.value);
         PlayerPrefs.SetInt("DiplomacyScale", DiplomacyScale.value);
         PlayerPrefs.SetInt("MaxSpellLevelDrop", MaxSpellLevelDrop.value + 1);
@@ -1469,6 +1475,18 @@ public class ContentSettings : MonoBehaviour
     {
         DiplomacyScale.interactable = Diplomacy.isOn;
         LockedAIRelations.interactable = Diplomacy.isOn;
+    }
+
+    public void SurrenderChanged()
+    {
+        if (AutoSurrender.isOn == true)
+        {
+            GoddessMercy.interactable = true;
+        }
+        else if (AutoSurrender.isOn == false)
+        {
+            GoddessMercy.interactable = false;
+        }
     }
 
     public void Exit()

--- a/Assets/Scripts/Subwindows/ContentSettings.cs
+++ b/Assets/Scripts/Subwindows/ContentSettings.cs
@@ -79,6 +79,7 @@ public class ContentSettings : MonoBehaviour
     public Toggle DayNightRandom;
     public Toggle NightMonsters;
     public Toggle NightMoveMonsters;
+    public Toggle MonsterMPBonus;
     public Slider NightRounds;
     public Slider BaseNightChance;
     public Slider NightChanceIncrease;
@@ -383,6 +384,7 @@ public class ContentSettings : MonoBehaviour
             new ToggleObject(DayNightRandom, "DayNightRandom", true),
             new ToggleObject(NightMonsters, "NightMonsters", false),
             new ToggleObject(NightMoveMonsters, "NightMoveMonsters", false),
+            new ToggleObject(MonsterMPBonus, "MonsterMPBonus", false),
             new ToggleObject(CombatComplicationsEnabled, "CombatComplicationsEnabled", false),
             new ToggleObject(StatCrit, "StatCrit", false),
             new ToggleObject(StatGraze, "StatGraze", false),
@@ -762,7 +764,7 @@ public class ContentSettings : MonoBehaviour
         Config.World.SurrenderedPredEscapeMult = PlayerPrefs.GetFloat("SurrenderedPredEscapeMult", 1);
         Config.World.SurrenderedPredAutoRegur = PlayerPrefs.GetFloat("SurrenderedPredAutoRegur", 0);
         Config.World.ArmyMP = PlayerPrefs.GetInt("ArmyMP", 3);
-        Config.World.ScoutMP = PlayerPrefs.GetInt("ScoutMP", 6);
+        Config.World.ScoutMP = PlayerPrefs.GetInt("ScoutMP", 3);
         Config.World.ScoutMax = PlayerPrefs.GetInt("ScoutMax", 4);
         Config.World.ArmyCreationMPMod = PlayerPrefs.GetFloat("ArmyCreationMPMod", 0);
         Config.World.ArmyCreationMPCurve = PlayerPrefs.GetFloat("ArmyCreationMPCurve", 1f);

--- a/Assets/Scripts/Utility/Texts/DefaultTooltips.cs
+++ b/Assets/Scripts/Utility/Texts/DefaultTooltips.cs
@@ -758,6 +758,8 @@ Does not retroactively affect already created units.";
                 return "Enables wandering pods of Feral Orcas";
             case 310:
                 return "Decides if and how the resource gain percentage setting is linked to ramp stacks. Can be used with settings that change stacks during absorbtion. \nMultiplicative: Multiplies resource gain by the bonus, will bottom out at zero health/mana per turn when a unit reaches zero stacks \nAdditive: Adds bonus onto the resourse gain, will bottom out at the normal value when stacks are zero.";
+            case 311:
+                return "If on, monster armies are able to receive the scout MP bonus.";
             default:
                 return "";
         }

--- a/Assets/Scripts/Utility/Texts/DefaultTooltips.cs
+++ b/Assets/Scripts/Utility/Texts/DefaultTooltips.cs
@@ -760,6 +760,8 @@ Does not retroactively affect already created units.";
                 return "Decides if and how the resource gain percentage setting is linked to ramp stacks. Can be used with settings that change stacks during absorbtion. \nMultiplicative: Multiplies resource gain by the bonus, will bottom out at zero health/mana per turn when a unit reaches zero stacks \nAdditive: Adds bonus onto the resourse gain, will bottom out at the normal value when stacks are zero.";
             case 311:
                 return "If on, monster armies are able to receive the scout MP bonus.";
+            case 312:
+                return "Controls if when a unit auto-surrenders if they are healed to full health. Can be changed from if only defecting units are healed, only units that remain loyal are healed, or if all auto-surrendered unit are healed.";
             default:
                 return "";
         }


### PR DESCRIPTION
Adds option to control if Auto-surrendered units regain all of their HP when they surrendered with options to: Disable, Affect Loyal units only, Affect Defecting units only, or both.
Also displays a message in tac log to let the player know the unit has regained their HP e.g. "A light shines from above on {Unit.Name}"