### PR TITLE
Further refining Scout MP

### DIFF
--- a/Assets/Scripts/Entities/Village.cs
+++ b/Assets/Scripts/Entities/Village.cs
@@ -1187,6 +1187,10 @@ public class Village
         {
             if (army.Units.Count < army.MaxSize)
             {
+                if ((army.Units.Count + 1) > Config.ScoutMax && army.RemainingMP > Config.ArmyMP)
+                {
+                    army.RemainingMP = Config.ArmyMP;
+                }
                 if (VillagePopulation.GetRecruitables().Where(rec => rec.IsInfiltratingSide(Side)).Count() > 0 && army.Side == Side && State.Rand.Next(2) < 1)
                 {
                     Unit unit = VillagePopulation.GetRecruitables().Where(rec => rec.IsInfiltratingSide(Side)).OrderByDescending(s => s.Experience).First();


### PR DESCRIPTION
Prevents AI from maintaining and using scout MP bonus after recruiting new units in the same turn (Was fixed for player empires but apparently not AI empires in a previous fix)