### PR TITLE
Small adjustments&fixes

### DIFF
--- a/Assets/Scripts/AI/Monsters/MonsterStrategicAI.cs
+++ b/Assets/Scripts/AI/Monsters/MonsterStrategicAI.cs
@@ -365,7 +365,7 @@ class MonsterStrategicAI : IStrategicAI
             }
         }
         Debug.Log(timedMovementType);
-        if ((spawner.MonsterScoutMP) && army.RemainingMP > Config.ArmyMP)
+        if ((!spawner.MonsterScoutMP) && army.RemainingMP > Config.ArmyMP)
             army.RemainingMP = Config.ArmyMP;
         if(timedMovementType == Config.DayNightMovemntType.Night && !State.World.IsNight && Config.DayNightEnabled) //DayNight Modification (zero's out monster AP based on their settings)
         {

--- a/Assets/Scripts/Entities/Units/PredatorComponent.cs
+++ b/Assets/Scripts/Entities/Units/PredatorComponent.cs
@@ -2948,6 +2948,10 @@ public class PredatorComponent
         int actorMaxHeal = actor.Unit.MaxHealth - actor.Unit.Health;
         if (r > v)
         {
+            if (!target.Unit.HasBreasts && target.Unit.HasDick)
+            {
+                (suckle[2]) = (3);
+            }
             switch (suckle[2])
             {
                 case 0:
@@ -2969,6 +2973,10 @@ public class PredatorComponent
         {
             actor.Unit.GiveRawExp(suckle[1]);
             actor.UnitSprite.DisplayDamage(suckle[1], false, true);
+            if (!target.Unit.HasBreasts && target.Unit.HasDick)
+            {
+                (suckle[2]) = (3);
+            }
             switch (suckle[2])
             {
                 case 0:

--- a/Assets/Scripts/Subwindows/ContentSettings.cs
+++ b/Assets/Scripts/Subwindows/ContentSettings.cs
@@ -228,7 +228,6 @@ public class ContentSettings : MonoBehaviour
     public Slider ScoutMax;
     public Slider ArmyCreationMPMod;
     public Slider ArmyCreationMPCurve;
-    public Toggle MonsterScoutMP;
 
     public Slider CustomEventFrequency;
 

--- a/Assets/Scripts/Utility/EventList.cs
+++ b/Assets/Scripts/Utility/EventList.cs
@@ -1518,9 +1518,16 @@ internal class EventList
                     UI.FirstChoice.GetComponentInChildren<Text>().text = $"Suffer not this beast, slay it and bring justice to the names of those it has already devoured.";
                     UI.FirstChoice.onClick.AddListener(() =>
                     {
+                        var garrison = village.PrepareAndReturnGarrison();
+                        if ((State.Rand.Next(5) >= 1) && (garrison.Count > 0))
+                        {
+                            State.GameManager.CreateMessageBox($"The canid, although great was successfully slain by the city's garrison. A day after the beast's demise we receive a gift of gold from the village as thanks for our intervention.\n\nVillage Happiness +10, Gold +160");
+                            village.Happiness += 10;
+                            empire.AddGold(160);
+                        }
+                        else
                         {
                             State.GameManager.CreateMessageBox($"The sizable canid has devoured the entire garrison with relative ease, snapping up and gulping down each and every soldier, one by one. It's gurgling stomach heard from nearby over the entire night. At sunrise, it pads out of its domicile, fattened up generously by its latest meal, and it heads off for less fattening lands. Whilst there was a grevious loss, at least the beast was driven away.");
-                            var garrison = village.PrepareAndReturnGarrison();
                             foreach (var unit in garrison)
                             {
                                 village.VillagePopulation.RemoveHireable(unit);
@@ -1573,29 +1580,38 @@ internal class EventList
                     {
                         {
                             var garrison = village.PrepareAndReturnGarrison();
-                            foreach (var unit in garrison)
+                            if ((State.Rand.Next(2) == 0) && (garrison.Count > 0))
                             {
-                                village.VillagePopulation.RemoveHireable(unit);
-                                village.SubtractPopulation(1);
+                                State.GameManager.CreateMessageBox($"The garrison successfully baits the creature out of it's den, once out they slowly lure it away from the village into the wilderness. The villagers are relieved to have the predator dealt with. The child, although sad that their \"kitty\" is gone, is happy knowing that it wasn’t harmed and is free to eat all it wants.\n\nVillage Happiness +20, Gold +100");
+                                empire.AddGold(100);
+                                village.Happiness += 20;
                             }
-                            village.SubtractPopulation(village.Maxpop / 6);
-                            village.SetPopulationToAtleastTwo();
-                            empire.AddGold(50);
-                            village.Happiness += 10;
-                            Unit youth = new Unit(empire.Side, empire.ReplacedRace, village.GetStartingXp(), empire.CanVore && !State.RaceSettings.Get(empire.ReplacedRace).RaceTraits.Contains(Traits.Prey));
-                            youth.Items[0] = State.World.ItemRepository.GetItem(ItemType.CompoundBow);
-                            Unit lion = new Unit(empire.Side, Race.FeralLions, 0, true);
-                            lion.AddPermanentTrait(Traits.Large);
-                            lion.AddPermanentTrait(Traits.IronGut);
-                            lion.AddPermanentTrait(Traits.StrongGullet);
-                            youth.AddPermanentTrait(Traits.PleasurableTouch);
-                            lion.Name = "Kitty";
-                            lion.DigestedUnits = State.Rand.Next(village.Maxpop / 6, (int)(village.Maxpop / 4));
-                            lion.GiveExp(lion.DigestedUnits * 10);
-                            State.GameManager.CreateMessageBox($"Dear government,\n\nKitty would like to say thanks for the treat, but I think something about soldier equipment makes {(lion.GetPronoun(2))} gassy, heheh. Anyways, it's been feeling pretty noisy here for Kitty so we'll leave!\nXOXO Kitty and {youth.Name} \n\nOn the bright side, we could recover all the victims' valuables and the remaining citizens are thankful for our efforts.\n\nVillage Happiness +10, Gold +50, Garrison wiped out, Population -{(village.Maxpop / 6)}, The duo is still out there");
-                            var armyName = $"Kitty and {youth.Name}";
-                            Empire kittyEmp = CreateFactionlessArmy(village, 57, new[] { lion, youth }, 10, armyName);
-                            kittyEmp.Name = armyName;
+                            else
+                            {
+                                foreach (var unit in garrison)
+                                {
+                                    village.VillagePopulation.RemoveHireable(unit);
+                                    village.SubtractPopulation(1);
+                                }
+                                village.SubtractPopulation(village.Maxpop / 6);
+                                village.SetPopulationToAtleastTwo();
+                                empire.AddGold(50);
+                                village.Happiness += 10;
+                                Unit youth = new Unit(empire.Side, empire.ReplacedRace, village.GetStartingXp(), empire.CanVore && !State.RaceSettings.Get(empire.ReplacedRace).RaceTraits.Contains(Traits.Prey));
+                                youth.Items[0] = State.World.ItemRepository.GetItem(ItemType.CompoundBow);
+                                Unit lion = new Unit(empire.Side, Race.FeralLions, 0, true);
+                                lion.AddPermanentTrait(Traits.Large);
+                                lion.AddPermanentTrait(Traits.IronGut);
+                                lion.AddPermanentTrait(Traits.StrongGullet);
+                                youth.AddPermanentTrait(Traits.PleasurableTouch);
+                                lion.Name = "Kitty";
+                                lion.DigestedUnits = State.Rand.Next(village.Maxpop / 6, (int)(village.Maxpop / 4));
+                                lion.GiveExp(lion.DigestedUnits * 10);
+                                State.GameManager.CreateMessageBox($"Dear government,\n\nKitty would like to say thanks for the treat, but I think something about soldier equipment makes {(lion.GetPronoun(2))} gassy, heheh. Anyways, it's been feeling pretty noisy here for Kitty so we'll leave!\nXOXO Kitty and {youth.Name} \n\nOn the bright side, we could recover all the victims' valuables and the remaining citizens are thankful for our efforts.\n\nVillage Happiness +10, Gold +50, Garrison wiped out, Population -{(village.Maxpop / 6)}, The duo is still out there");
+                                var armyName = $"Kitty and {youth.Name}";
+                                Empire kittyEmp = CreateFactionlessArmy(village, 57, new[] { lion, youth }, 10, armyName);
+                                kittyEmp.Name = armyName;
+                            }
                         }
 
                     });
@@ -1716,7 +1732,7 @@ internal class EventList
                     UI.ThirdChoice.onClick.AddListener(() =>
                     {
                         Unit unit;
-                        for (int x = 0; x < 2; x++)
+                        for (int x = 0; x < 3; x++)
                         {
                             unit = new Unit(empire.Side, Race.Kobolds, village.GetStartingXp(), true);
                             unit.AddPermanentTrait(Traits.PackVoracity);

--- a/Assets/Scripts/Utility/EventList.cs
+++ b/Assets/Scripts/Utility/EventList.cs
@@ -1351,14 +1351,14 @@ internal class EventList
                         if (State.Rand.Next(3) != 0)
                         {
                             empire.AddGold(1000);
-                            otherEmpire.AddGold(9000);
+                            otherEmpire.AddGold(1000);
                             RelationsManager.ChangeRelations(empire, otherEmpire, 5);
                             RelationsManager.ChangeRelations(otherEmpire, empire, 5);
                             State.GameManager.CreateMessageBox($"While initially concerned with the aspect of a foreign agent infiltrating their city, {otherEmpire.Name} appreciates the gesture of coming to them with the information damming the corrupt magistrate. It doesn’t take long before torture unveils the location of the hidden funds. While the locals take most of their stolen money back to their treasury, they do give a sizable sum to us as thanks for our contribution in finding the assailant.");
                         }
                         else
                         {
-                            otherEmpire.AddGold(10000);
+                            otherEmpire.AddGold(1200);
                             RelationsManager.ChangeRelations(empire, otherEmpire, -5);
                             RelationsManager.ChangeRelations(otherEmpire, empire, -5);
                             State.GameManager.CreateMessageBox($"After being informed to reveal themselves to the {otherEmpire.Name} authorities communications with our infiltrator go dark. Several days later we receive a package containing the partially digested skull of our agent. It would seem that our neighbors wish us to have no illusions to the fate of spies.");
@@ -1377,8 +1377,8 @@ internal class EventList
                     {
                         if (State.Rand.Next(3) == 0)
                         {
-                            empire.AddGold(10000);
-                            State.GameManager.CreateMessageBox($"In a stroke of luck, our agent was able to enter the magistrate’s home. While they slept our clever agent managed to silently swallow the corrupt official whole. Utilizing tightfitting garb, the infiltrator manages to compress their sloshing belly enough to make them seem heavily pregnant.  \nUpon reaching the city gates, they convince the guards that they are a spurned lover that has been banished from their partner’s estate. The sob story convinces them and they’re allowed to pass. Once far enough away the magistrate is regurgitated, still asleep and only suffering minor acid burns.Their interrogation leads our troops to a small fortune! (10,000 gold) ");
+                            empire.AddGold(1000);
+                            State.GameManager.CreateMessageBox($"In a stroke of luck, our agent was able to enter the magistrate’s home. While they slept our clever agent managed to silently swallow the corrupt official whole. Utilizing tightfitting garb, the infiltrator manages to compress their sloshing belly enough to make them seem heavily pregnant.  \nUpon reaching the city gates, they convince the guards that they are a spurned lover that has been banished from their partner’s estate. The sob story convinces them and they’re allowed to pass. Once far enough away the magistrate is regurgitated, still asleep and only suffering minor acid burns.Their interrogation leads our troops to a small fortune! (1,000 gold) ");
                         }
                         else
                         {
@@ -1407,7 +1407,7 @@ internal class EventList
                         }
                         else
                         {
-                            otherEmpire.AddGold(10000);
+                            otherEmpire.AddGold(1000);
                             RelationsManager.ChangeRelations(empire, otherEmpire, -3);
                             ChangeAllVillageHappiness(otherEmpire, 20);
                             State.GameManager.CreateMessageBox($"Our attempts to intercede have been mistakenly interpreted as an aggressive maneuver to take over the house’s territory. The scions immediately rally under the leadership of their most martial sibling and begin pressuring their state to wage war against us.  \nWhile not what we wanted, the schism seems unlikely now.");

--- a/Assets/Scripts/Utility/Texts/DefaultTooltips.cs
+++ b/Assets/Scripts/Utility/Texts/DefaultTooltips.cs
@@ -763,7 +763,7 @@ Does not retroactively affect already created units.";
             case 312:
                 return "Changes the time of day when monsters are given AP. \n'Can always move' respects 'Monsters can only move at night' setting preventing movement \n'Can only move when Day' allows for movement durring day despite 'Monsters can only move at night' setting.";
             case 313:
-                return "Controls if when a unit auto-surrenders if they are healed to full health. Can be changed from if only defecting units are healed, only units that remain loyal are healed, or if all auto-surrendered unit are healed.";
+                return "Controls if when a unit auto-surrenders if they are healed to full health. Can be changed from if only defecting units are healed, only units that remain loyal are healed, or if all auto-surrendered units are healed.";
             default:
                 return "";
         }

--- a/Assets/Scripts/Utility/Texts/HoveringTooltip.cs
+++ b/Assets/Scripts/Utility/Texts/HoveringTooltip.cs
@@ -600,7 +600,7 @@ public class HoveringTooltip : MonoBehaviour
             case Traits.Annihilation:
                 return "Every time digestion progresses, this unit digests one level from each prey inside them, gaining its experience value. If a unit hits level 0 this way, it dies if it was stil alive and cannot be revived.\n(Cheat Trait)";
             case Traits.WeaponChanneler:
-                return "Unit deals extra melee or ranged damage at the cost of each attack consuming 6 mana. No bonus is received if mana is under.";
+                return "Unit deals extra melee or ranged damage at the cost of each srtike consuming 6 mana. No bonus is received if mana is under 6.";
         }  
         return "<b>This trait needs a tooltip!</b>";
     }


### PR DESCRIPTION
A collection of small fixes to help polish the game from complaints I've seen in discord and issues I've encountered myself, janitorial work of sorts.
Changes so far:

-Suckle
>Now accurately shows tac log reflecting for units that don't have breasts when using infinite suckle glitch/feature

-Spelling & grammar
>Goddess' mercy description
>WeaponChanneler description

-MonsterScoutMP
>Old 'all or nothing' button removed
>New 'individual monster' button's logic has been fixed as it was inverted in logic (e.g. on = off and off = on)

-Events
>Adjusted game breaking 10,000 gold events with much more reasonable numbers
>Feral wolf event option 1 now has 75% chance to have a "win" outcome
>Kitty event option 1 now has a 50% "win" outcome
>Kobold Alchemist event now actually gives 3 kobolds instead of 2