### PR TITLE
Oral to Oral vore Stealing and Transferring added

### DIFF
--- a/Assets/Scripts/Entities/Units/PredatorComponent.cs
+++ b/Assets/Scripts/Entities/Units/PredatorComponent.cs
@@ -2829,6 +2829,37 @@ public class PredatorComponent
         return 0;
     }
 
+    public bool CanKissTransfer()
+    {
+        if (Config.TransferAllowed == false || Config.KuroTenkoEnabled == false)
+            return false;
+        return GetKissTransfer() != null;
+    }
+
+    private Prey GetKissTransfer()
+    {
+        foreach (Prey preyUnit in stomach)
+        {
+            if (preyUnit.Unit.IsDead == false)
+            {
+            return preyUnit;
+            }
+        }
+        return null;
+    }
+
+    public float GetKissTransferBulk()
+    {
+        foreach (Prey preyUnit in stomach)
+        {
+            if (preyUnit.Unit.IsDead == false)
+            {
+            return preyUnit.Actor.Bulk();
+            }
+        }
+        return 0;
+    }
+
     public float GetSuckleChance(Actor_Unit target, bool includeSecondaries = false)
     {
         if (target.Surrendered || actor.Unit.GetApparentSide() == target.Unit.FixedSide)
@@ -3070,6 +3101,17 @@ public class PredatorComponent
             }
 
         }
+        if (State.RaceSettings.GetVoreTypes(actor.Unit.Race).Contains(VoreType.Oral))
+        {
+            foreach (Prey preyUnit in target.PredatorComponent.stomach)
+            {
+                if (!preyUnit.Unit.IsDead)
+                {
+                    return preyUnit;
+                }
+            }
+
+        }
         return null;
     }
 
@@ -3097,6 +3139,15 @@ public class PredatorComponent
         return transfer.Actor.Bulk();
     }
 
+    public float KissTransferBulk()
+    {
+        Prey transfer = GetKissTransfer();
+        if (transfer == null)
+        {
+            return 999f;
+        }
+        return transfer.Actor.Bulk();
+    }
     public float StealBulk()
     {
         Prey transfer = GetVoreSteal(actor);
@@ -3347,6 +3398,25 @@ public class PredatorComponent
         return true;
     }
 
+    private bool KissTransfer(Actor_Unit target, Prey preyUnit)
+    {
+        Prey preyref = new Prey(preyUnit.Actor, target, preyUnit.Actor.PredatorComponent?.prey);
+        if (target.Position.GetNumberOfMovesDistance(actor.Position) > 1)
+        {
+            return false;
+        }
+        else
+        {
+            KissTransferFinalize(target, preyUnit, preyref, PreyLocation.stomach);
+        }
+        if (target.UnitSprite != null)
+        {
+            target.UnitSprite.UpdateSprites(actor, true);
+            target.UnitSprite.AnimateBellyEnter();
+        }
+        return true;
+    }
+
     private bool TransferFinalize(Actor_Unit recipient, Prey preyUnit, Prey preyref, PreyLocation destination)
     {
         // Empowerment handling
@@ -3416,6 +3486,33 @@ public class PredatorComponent
         UpdateFullness();
         return true;
     }
+	
+    private bool KissTransferFinalize(Actor_Unit recipient, Prey preyUnit, Prey preyref, PreyLocation destination)
+    {
+        if (preyUnit.Unit.IsDead == false)
+        {
+            recipient.PredatorComponent.AlivePrey++;
+            actor.PredatorComponent.AlivePrey--;
+        } else if (unit.HasTrait(Traits.Corruption))
+        {
+            recipient.AddCorruption(preyUnit.Unit.GetStatTotal()/2, unit.FixedSide);
+        }
+        else if (preyUnit.Unit.HasTrait(Traits.Corruption))
+            recipient.AddCorruption(preyUnit.Unit.GetStatTotal() / 2, preyUnit.Unit.FixedSide);
+        switch (destination)
+        {
+            default:
+                recipient.PredatorComponent.AddToStomach(preyref, 1.0f);
+                TacticalUtilities.Log.RegisterKissTransfer(unit, recipient.Unit, preyUnit.Unit, 1.0f, PreyLocation.stomach);
+                break;
+        }
+        recipient.PredatorComponent.AddPrey(preyref);
+        recipient.Unit.GiveScaledExp(4 * preyUnit.Unit.ExpMultiplier, recipient.Unit.Level - preyUnit.Unit.Level, true);
+        recipient.PredatorComponent.UpdateFullness();
+        actor.PredatorComponent.RemovePrey(preyUnit);
+        UpdateFullness();
+        return true;
+    }
 
     public bool TransferAttempt(Actor_Unit target)
     {
@@ -3452,9 +3549,52 @@ public class PredatorComponent
         return true;
     }
 
+    public bool KissTransferAttempt(Actor_Unit target)
+    {
+        if (actor.Unit.Predator == false || target.Unit.Predator == false)
+            return false;
+        if (target.Unit.Side != actor.Unit.Side || target.Surrendered)
+        {
+            return false;
+        }
+        if (target.Position.GetNumberOfMovesDistance(actor.Position) > 1)
+        {
+            return false;
+        }
+        if (target == actor)
+        {
+            return false;
+        }
+        if (actor.Movement == 0)
+        {
+            return false;
+        }
+        if (!CanKissTransfer())
+        {
+            return false;
+        }
+        Prey transfer = GetKissTransfer();
+        if (target.PredatorComponent.FreeCap() < transfer.Actor.Bulk() && !(target.Unit == actor.Unit))
+        {
+            return false;
+        }
+        if (!KissTransfer(target, transfer))
+        {};
+        int thirdMovement = (int)Math.Ceiling(actor.MaxMovement() / 3.0f);
+        if (actor.Movement > thirdMovement)
+            actor.Movement -= thirdMovement;
+        else
+            actor.Movement = 0;
+        return true;
+    }
+
     public bool VoreStealAttempt(Actor_Unit target)
     {
         if (target.Position.GetNumberOfMovesDistance(actor.Position) > 1)
+        {
+            return false;
+        }
+        if (target == actor)
         {
             return false;
         }

--- a/Assets/Scripts/Enums/SpecialAction.cs
+++ b/Assets/Scripts/Enums/SpecialAction.cs
@@ -6,6 +6,7 @@
     TailVore,
     AnalVore,
     Transfer,
+    KissTransfer,
     StealVore,
     BreastVore,
     BreastFeed,

--- a/Assets/Scripts/Modes/Tactical/Log/StoredLogTexts.cs
+++ b/Assets/Scripts/Modes/Tactical/Log/StoredLogTexts.cs
@@ -48,6 +48,7 @@ static class StoredLogTexts
         TailRubMessages,
         BallMassageMessages,
         TransferMessages,
+        KissTransferMessages,
         VoreStealMessages,
         BreastFeedMessages,
         CumFeedMessages,
@@ -87,6 +88,8 @@ static class StoredLogTexts
                 return BallMassageMessages;
             case MessageTypes.TransferMessages:
                 return TransferMessages;
+            case MessageTypes.KissTransferMessages:
+                return KissTransferMessages;
             case MessageTypes.VoreStealMessages:
                 return VoreStealMessages;
             case MessageTypes.BreastFeedMessages:
@@ -116,6 +119,7 @@ static class StoredLogTexts
     internal static List<EventString> TailRubMessages;
     internal static List<EventString> BallMassageMessages;
     internal static List<EventString> TransferMessages;
+    internal static List<EventString> KissTransferMessages;
     internal static List<EventString> VoreStealMessages;
     internal static List<EventString> BreastFeedMessages;
     internal static List<EventString> CumFeedMessages;
@@ -2435,8 +2439,34 @@ static class StoredLogTexts
             new EventString((i) => $"<b>{i.Target.Name}</b> wraps {GPPHis(i.Unit)} mouth around <b>{ApostrophizeWithOrWithoutS(i.Unit.Name)}</b> member and begins servicing it. <b>{i.Unit.Name}</b> can't hold on any longer and blows {GPPHis(i.Unit)} load into <b>{ApostrophizeWithOrWithoutS(i.Target.Name)}</b> mouth. <b>{i.Target.Name}</b> swallows most of it and {GPPHis(i.Target)} belly bloats out.",
             priority: 11, conditional: s => InStomach(s) && Lewd(s)),
         };
+
+        KissTransferMessages = new List<EventString>()
+        {
+            new EventString((i) => $"<b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b>, causing <b>{ApostrophizeWithOrWithoutS(i.Target.Name)}</b> belly to {GetRandomStringFrom("suddenly", "instanlty", "inexplicably")} be filled with <b>{i.Prey.Name}</b>, <b>{i.Target.Name}</b> although {GetRandomStringFrom("satisfied", "full", "content")} is utterly baffled as to how it occurred.",
+            priority: 10, conditional: s => InStomach(s) && !s.Prey.IsDead ),
+            new EventString((i) => $"<b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b>, instanlty giving <b>{i.Prey.Name}</b> in the process, {GetRandomStringFrom("satisfied", "pleased", "content")} with the outcome <b>{i.Target.Name}</b> happily pats {GPPHis(i.Unit)} belly.",
+            priority: 10, conditional: s => InStomach(s) && !s.Prey.IsDead ),
+            new EventString((i) => $"<b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b>, and {GetRandomStringFrom("in less than a second", "instanlty", "without warning")} <b>{ApostrophizeWithOrWithoutS(i.Target.Name)}</b> belly is filled with <b>{i.Prey.Name}</b>. <b>{i.Unit.Name}</b> simply says \"You're welcome!\" as <b>{i.Target.Name}</b> just stands, puzzled as to what just happened.",
+            priority: 10, conditional: s => InStomach(s) && !s.Prey.IsDead ),
+            new EventString((i) => $"<b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b>, instanlty sharing <b>{i.Prey.Name}</b> with {GPPHim(i.Unit)} in the process. After pulling away from the first kiss <b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b> a second time {GetRandomStringFrom("in the heat of the moment", "just for fun", "just for good measure", "as a gift")}, <b>{i.Target.Name}</b> blushes profusely.",
+            priority: 10, conditional: s => InStomach(s) && !s.Prey.IsDead && ReqOSW(s)),
+        };
+
         VoreStealMessages = new List<EventString>()
         {
+            //Oral to Oral vore steal
+            new EventString((i) => $"<b>{i.Unit.Name}</b> {GetRandomStringFrom("tackles", "headbutts", "charges into", "bashes")} <b>{ApostrophizeWithOrWithoutS(i.Target.Name)}</b> {GetRandomStringFrom("filled", "bulbus", "exposed")} belly forcing {GPPHim(i.Target)} to {GetRandomStringFrom("regurgitate", "free", "release")} <b>{i.Prey.Name}</b> into the air who <b>{i.Unit.Name}</b> deftly catches in {GPPHis(i.Unit)} mouth.",
+            priority: 10, conditional: s => s.oldLocation == PreyLocation.stomach && s.preyLocation == PreyLocation.stomach),
+            // Friendly Oral to Oral vore steal
+            new EventString((i) => $"<b>{i.Unit.Name}</b> goes to kiss <b>{i.Target.Name}</b> and is quickly surprised to find <b>{i.Prey.Name}</b> {GetRandomStringFrom("suddenly", "instanlty", "inexplicably")} inside of {GPPHis(i.Unit)} stomach, <b>{i.Unit.Name}</b> and <b>{i.Target.Name}</b> are both equally confused as to how this happened but neither {GetRandomStringFrom("mind", "complain about", "object")} the outcome.",
+            priority: 12, conditional: s => s.oldLocation == PreyLocation.stomach && s.preyLocation == PreyLocation.stomach && Friendly(s)),
+            new EventString((i) => $"<b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b>, after pulling back {GPPHe(i.Unit)} is pleasantly surprised to find <b>{i.Prey.Name}</b> now residing inside of {GPPHis(i.Unit)} belly, meanwhile <b>{i.Target.Name}</b> can't help but miss the full feeling {GPPHe(i.Target)} had.",
+            priority: 12, conditional: s => s.oldLocation == PreyLocation.stomach && s.preyLocation == PreyLocation.stomach && Friendly(s)),
+            new EventString((i) => $"<b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b>, after pulling back {GPPHe(i.Unit)} is pleasantly surprised to find <b>{i.Prey.Name}</b> now residing inside of {GPPHis(i.Unit)} belly, meanwhile <b>{i.Target.Name}</b> can't help but feel slightly cheated.",
+            priority: 12, conditional: s => s.oldLocation == PreyLocation.stomach && s.preyLocation == PreyLocation.stomach && Friendly(s)),
+            new EventString((i) => $"As <b>{i.Unit.Name}</b> pulls back from {GPPHis(i.Unit)} kiss with <b>{i.Target.Name}</b>, is confused as to how <b>{i.Prey.Name}</b> is now {GPPHis(i.Unit)} in belly, however {GPPHe(i.Unit)} immediately stops caring as <b>{i.Target.Name}</b> {GetRandomStringFrom("pats", "rubs", "massages")} {GPPHis(i.Unit)} belly.",
+            priority: 12, conditional: s => s.oldLocation == PreyLocation.stomach && s.preyLocation == PreyLocation.stomach && Friendly(s)),
+
             // If you can make this not lewd, please advise, otherwise I may need to lock the whole mechanic behind lewd texts
             new EventString((i) => $"<b>{i.Unit.Name}</b> tackles <b>{i.Target.Name}</b> and rides {GPPHim(i.Target)} until {GPPHe(i.Target)} release{SIfSingular(i.Target)} <b>{i.Prey.Name}</b> into {GPPHis(i.Unit)} womb.",
             priority: 10, conditional: s => s.oldLocation == PreyLocation.balls && s.preyLocation == PreyLocation.womb),

--- a/Assets/Scripts/Modes/Tactical/Log/StoredLogTexts.cs
+++ b/Assets/Scripts/Modes/Tactical/Log/StoredLogTexts.cs
@@ -2442,6 +2442,7 @@ static class StoredLogTexts
 
         KissTransferMessages = new List<EventString>()
         {
+            //The main idea behind most of the dialouge was, how in several Kirby games Kirby share health pickups with his allies via kissing them and they would still somehow get the full effect of the heal, just seemed too good to pass up. Also the alternative is mother bird-like stuff going on and I ain't writing that -Wolfwar
             new EventString((i) => $"<b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b>, causing <b>{ApostrophizeWithOrWithoutS(i.Target.Name)}</b> belly to {GetRandomStringFrom("suddenly", "instanlty", "inexplicably")} be filled with <b>{i.Prey.Name}</b>, <b>{i.Target.Name}</b> although {GetRandomStringFrom("satisfied", "full", "content")} is utterly baffled as to how it occurred.",
             priority: 10, conditional: s => InStomach(s) && !s.Prey.IsDead ),
             new EventString((i) => $"<b>{i.Unit.Name}</b> kisses <b>{i.Target.Name}</b>, instanlty giving <b>{i.Prey.Name}</b> in the process, {GetRandomStringFrom("satisfied", "pleased", "content")} with the outcome <b>{i.Target.Name}</b> happily pats {GPPHis(i.Unit)} belly.",

--- a/Assets/Scripts/Modes/Tactical/TacticalAction.cs
+++ b/Assets/Scripts/Modes/Tactical/TacticalAction.cs
@@ -141,6 +141,14 @@ static class TacticalActionList
         TargetedDictionary[SpecialAction.Transfer] = TargetedActions.Last();
 
         TargetedActions.Add(new TargetedTacticalAction(
+            name: "Kiss Transfer",
+            requiresPred: true,
+            conditional: (a) => a.PredatorComponent?.CanKissTransfer() ?? false,
+            onClicked: () => State.GameManager.TacticalMode.TrySetSpecialMode(SpecialAction.KissTransfer),
+            onExecute: (a, t) => a.PredatorComponent.KissTransferAttempt(t)));
+        TargetedDictionary[SpecialAction.KissTransfer] = TargetedActions.Last();
+
+        TargetedActions.Add(new TargetedTacticalAction(
             name: "Vore Steal",
             requiresPred: true,
             conditional: (a) => Config.TransferAllowed == true && Config.KuroTenkoEnabled == true && a.Unit.Predator,

--- a/Assets/Scripts/Modes/Tactical/TacticalMessageLog.cs
+++ b/Assets/Scripts/Modes/Tactical/TacticalMessageLog.cs
@@ -85,6 +85,7 @@ public class TacticalMessageLog
         Birth,
         TransferFail,
         TransferSuccess,
+        KissTransfer,
         Resist,
         Kill,
         Digest,
@@ -249,6 +250,8 @@ public class TacticalMessageLog
                 return GenerateBallMassageMessage(action);
             case MessageLogEvent.TransferSuccess:
                 return GetStoredMessage(StoredLogTexts.MessageTypes.TransferMessages, action);
+            case MessageLogEvent.KissTransfer:
+                return GetStoredMessage(StoredLogTexts.MessageTypes.KissTransferMessages, action);
             case MessageLogEvent.VoreStealSuccess:
                 return GetStoredMessage(StoredLogTexts.MessageTypes.VoreStealMessages, action);
             //return $"<b>{action.Target.Name}</b> gently pushes down <b>{action.Unit.Name}</b> as {GPPHe(action.Target)} straddles {GPPHim(action.Unit)}. As {GPPHe(action.Target)} rides {GPPHim(action.Unit)}, {GPPHe(action.Unit)} cums, shooting {GPPHis(action.Unit)} prey straight into {GPPHis(action.Target)} {action.preyLocation.ToSyn()}.{odds}";
@@ -257,6 +260,8 @@ public class TacticalMessageLog
             case MessageLogEvent.VoreStealFail:
                 if (action.oldLocation == PreyLocation.breasts || action.oldLocation == PreyLocation.leftBreast || action.oldLocation == PreyLocation.rightBreast)
                     return $"<b>{action.Target.Name}</b> shoves <b>{action.Unit.Name}</b> off of {GPPHim(action.Target)} before {GPPHe(action.Unit)} can suck <b>{action.Prey.Name}</b> out of {GPPHis(action.Target)} breasts.";
+                else if (action.oldLocation == PreyLocation.stomach)
+                    return $"<b>{action.Unit.Name}</b> {GetRandomStringFrom("tackles", "headbutts", "charges into", "bashes")} <b>{ApostrophizeWithOrWithoutS(action.Target.Name)}</b> {GetRandomStringFrom("filled", "bulbus", "exposed")} belly, but <b>{action.Target.Name}</b> refuses to let go of <b>{action.Prey.Name}</b> that easily.";
                 else
                     return $"<b>{action.Target.Name}</b> shoves <b>{action.Unit.Name}</b> off of {GPPHim(action.Target)} before {GPPHe(action.Unit)} can suck <b>{action.Prey.Name}</b> out of {GPPHis(action.Target)} balls.";
             case MessageLogEvent.Feed:
@@ -1061,6 +1066,20 @@ public class TacticalMessageLog
         events.Add(new EventLog
         {
             Type = MessageLogEvent.TransferSuccess,
+            Unit = donor,
+            Target = recipient,
+            Prey = donation,
+            Odds = odds,
+            preyLocation = loc,
+        });
+        UpdateListing();
+    }
+
+    public void RegisterKissTransfer(Unit donor, Unit recipient, Unit donation, float odds, PreyLocation loc)
+    {
+        events.Add(new EventLog
+        {
+            Type = MessageLogEvent.KissTransfer,
             Unit = donor,
             Target = recipient,
             Prey = donation,

--- a/Assets/Scripts/Modes/TacticalMode.cs
+++ b/Assets/Scripts/Modes/TacticalMode.cs
@@ -1775,6 +1775,9 @@ Turns: {currentTurn}
             case SpecialAction.Transfer:
                 ShowCockVoreTransferPercentages(actor);
                 break;
+            case SpecialAction.KissTransfer:
+                ShowKissVoreTransferPercentages(actor);
+                break;
             case SpecialAction.StealVore:
                 ShowVoreStealPercentages(actor);
                 break;
@@ -1865,6 +1868,30 @@ Turns: {currentTurn}
         }
 
     }
+    void ShowKissVoreTransferPercentages(Actor_Unit actor)
+    {
+        if (actor.Unit.Predator == false)
+            return;
+        foreach (Actor_Unit target in units)
+        {
+            if (target.Unit.Predator == false)
+                continue;
+            if (target.Unit.Side == actor.Unit.Side && target.Surrendered == false)
+            {
+                if (actor.PredatorComponent.CanKissTransfer())
+                {
+                    if (target.PredatorComponent.FreeCap() < actor.PredatorComponent.KissTransferBulk() && !(target.Unit == actor.Unit))
+                        target.UnitSprite.DisplayHitPercentage(target.GetSpecialChance(SpecialAction.KissTransfer), Color.yellow);
+                    else if ((actor.Position.GetNumberOfMovesDistance(target.Position) < 2) && !(target.Unit == actor.Unit))
+                        target.UnitSprite.DisplayHitPercentage(target.GetSpecialChance(SpecialAction.KissTransfer), Color.red);
+                    else
+                        target.UnitSprite.DisplayHitPercentage(target.GetSpecialChance(SpecialAction.KissTransfer), Color.black);
+                }
+                continue;
+            }
+        }
+
+    }
 
     void ShowVoreStealPercentages(Actor_Unit actor)
     {
@@ -1872,9 +1899,9 @@ Turns: {currentTurn}
         {
             if (!actor.PredatorComponent.CanVoreSteal(target))
                 continue;
-            if (actor.PredatorComponent.FreeCap() < target.PredatorComponent.StealBulk() && !(target.Unit == actor.Unit))
+            if (actor.PredatorComponent.FreeCap() < target.PredatorComponent.StealBulk() && (target.Unit != actor.Unit))
                 target.UnitSprite.DisplayHitPercentage(target.PredatorComponent.GetVoreStealChance(actor), Color.yellow);
-            else if (actor.Position.GetNumberOfMovesDistance(target.Position) < 2)
+            else if ((actor.Position.GetNumberOfMovesDistance(target.Position) < 2) && (target.Unit != actor.Unit))
                 target.UnitSprite.DisplayHitPercentage(target.PredatorComponent.GetVoreStealChance(actor), Color.red);
             else
                 target.UnitSprite.DisplayHitPercentage(target.PredatorComponent.GetVoreStealChance(actor), Color.black);

--- a/Assets/Scripts/UI/RightClickMenu.cs
+++ b/Assets/Scripts/UI/RightClickMenu.cs
@@ -635,6 +635,18 @@ public class RightClickMenu : MonoBehaviour
                     }
                     currentButton++;
                 }
+                if (actor.PredatorComponent.CanKissTransfer() && data.Target.Unit.Predator)
+                {
+                    Buttons[currentButton].onClick.AddListener(() => data.Actor.PredatorComponent.KissTransferAttempt(data.Target));
+                    Buttons[currentButton].onClick.AddListener(FinishAction);
+                    Buttons[currentButton].GetComponentInChildren<Text>().text = $"Kiss Transfer";
+                    if (data.Target.PredatorComponent.FreeCap() < actor.PredatorComponent.GetKissTransferBulk())
+                    {
+                        Buttons[currentButton].GetComponentInChildren<Text>().text = $"Too bulky to Transfer";
+                        Buttons[currentButton].interactable = false;
+                    }
+                    currentButton++;
+                }
             }
             else if (data.Actor.Unit != data.Target.Unit && data.Target.Unit.Predator)
             {


### PR DESCRIPTION
Allows units to vore steal and transfer units to and from another unit's stomach
(Inadvertently the oral vore steal doubles as a way to potentially save oral vored units from enemies) 

Several custom logs for these events have been added as well! 

Adjusted base vore steal to disallow units from vore stealing from themselves (Bug prevention)