### PR TITLE
Death cheater+respwaner traits

### DIFF
--- a/Assets/Scripts/Entities/Spells/SpellList.cs
+++ b/Assets/Scripts/Entities/Spells/SpellList.cs
@@ -458,6 +458,7 @@ static class SpellList
             Tier = 2,
             Pattern = new int[3, 3] { { 0, 1, 0 }, { 1, 1, 1 }, { 0, 1, 0 } },
             Resistable = true,
+            ResistanceMult = .80f,
             DamageType = DamageTypes.Fire,
             Damage = (a, t) => 8 + a.Unit.GetStat(Stat.Dexterity) / 9,
             OnExecute = (a, t) =>

--- a/Assets/Scripts/Entities/Spells/SpellList.cs
+++ b/Assets/Scripts/Entities/Spells/SpellList.cs
@@ -429,6 +429,7 @@ static class SpellList
             Tier = 1,
             Pattern = new int[3, 3] { { 0, 0, 0 }, { 1, 1, 1 }, { 0, 0, 0 } },
             Resistable = true,
+            DamageType = DamageTypes.Fire,
             Damage = (a, t) => 5 + a.Unit.GetStat(Stat.Mind) / 7,
             OnExecute = (a, t) =>
             {
@@ -457,6 +458,7 @@ static class SpellList
             Tier = 2,
             Pattern = new int[3, 3] { { 0, 1, 0 }, { 1, 1, 1 }, { 0, 1, 0 } },
             Resistable = true,
+            DamageType = DamageTypes.Fire,
             Damage = (a, t) => 8 + a.Unit.GetStat(Stat.Dexterity) / 9,
             OnExecute = (a, t) =>
             {

--- a/Assets/Scripts/Entities/Units/Actor_Unit.cs
+++ b/Assets/Scripts/Entities/Units/Actor_Unit.cs
@@ -265,6 +265,10 @@ public class Actor_Unit
 
     public int CurrentMaxMovement()
     {
+        if (Unit.HasTrait(Traits.Respawner) && State.GameManager.TacticalMode.currentTurn == 1)
+            Unit.AddRespawns(1);
+        if (Unit.HasTrait(Traits.RespawnerIII) && State.GameManager.TacticalMode.currentTurn == 1)
+            Unit.AddRespawns(3);
         int sizePenalty = (int)(PredatorComponent?.Fullness ?? 0);
         sizePenalty = (int)(sizePenalty * Unit.TraitBoosts.SpeedLossFromWeightMultiplier);
         int bonus = 0;
@@ -1530,6 +1534,21 @@ public class Actor_Unit
             GiveRandomBoost();
 
         Unit.GiveScaledExp(4 * target.Unit.ExpMultiplier, Unit.Level - target.Unit.Level);
+        if (target.Unit.GetStatusEffect(StatusEffectType.Respawns) != null)
+        {
+            var spawnLoc = TacticalUtilities.GetRandomTileForActor(target);
+            if (spawnLoc == null)
+                State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{target.Unit.Name} was unable to respawn!");
+            else
+                TacticalUtilities.Resurrect((spawnLoc),target);
+                TacticalGraphicalEffects.CreateGenericMagic(spawnLoc, spawnLoc, target, TacticalGraphicalEffects.SpellEffectIcon.Resurrect);
+                target.Unit.Health = target.Unit.MaxHealth;
+                target.Unit.RemoveRespawns();
+                if (target.Unit.Race != Race.Helldivers)
+                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{target.Unit.Name} has respawned!");
+                else
+                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"Reinforcements have arrived!");
+        }
     }
 
     private void KillUnit(Actor_Unit target, Spell spell)
@@ -1547,6 +1566,21 @@ public class Actor_Unit
         if (Unit.HasTrait(Traits.TasteForBlood))
             GiveRandomBoost();
         Unit.GiveScaledExp(4 * target.Unit.ExpMultiplier, Unit.Level - target.Unit.Level);
+        if (target.Unit.GetStatusEffect(StatusEffectType.Respawns) != null)
+        {
+            var spawnLoc = TacticalUtilities.GetRandomTileForActor(target);
+            if (spawnLoc == null)
+                State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{target.Unit.Name} was unable to respawn!");
+            else
+                TacticalUtilities.Resurrect((spawnLoc),target);
+                TacticalGraphicalEffects.CreateGenericMagic(spawnLoc, spawnLoc, target, TacticalGraphicalEffects.SpellEffectIcon.Resurrect);
+                target.Unit.Health = target.Unit.MaxHealth;
+                target.Unit.RemoveRespawns();
+                if (target.Unit.Race != Race.Helldivers)
+                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{target.Unit.Name} has respawned!");
+                else
+                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"Reinforcements have arrived!");
+        }
     }
 
     /// <summary>
@@ -2295,7 +2329,7 @@ public class Actor_Unit
                 Unit.ApplyStatusEffect(StatusEffectType.Berserk, 1, 3);
             }
         }
-        if ((canKill == false && Unit.IsDead) || (Config.AutoSurrender && Unit.IsDead && State.Rand.NextDouble() < Config.AutoSurrenderChance && Surrendered == false && Unit.HasTrait(Traits.Fearless) == false && !KilledByDigestion))
+        if ((canKill == false && Unit.IsDead) || (Config.AutoSurrender && Unit.IsDead && State.Rand.NextDouble() < Config.AutoSurrenderChance && Surrendered == false && Unit.HasTrait(Traits.Fearless) == false && !KilledByDigestion && Unit.GetStatusEffect(StatusEffectType.Respawns) == null))
         {
             Unit.Health = 1;
             Surrendered = true;

--- a/Assets/Scripts/Entities/Units/Actor_Unit.cs
+++ b/Assets/Scripts/Entities/Units/Actor_Unit.cs
@@ -265,9 +265,9 @@ public class Actor_Unit
 
     public int CurrentMaxMovement()
     {
-        if (Unit.HasTrait(Traits.Respawner) && State.GameManager.TacticalMode.currentTurn == 1)
+        if (Unit.HasTrait(Traits.Respawner) && (State.GameManager.TacticalMode.currentTurn == 1) && State.GameManager.TacticalMode.attackersTurnCheck == true)
             Unit.AddRespawns(1);
-        if (Unit.HasTrait(Traits.RespawnerIII) && State.GameManager.TacticalMode.currentTurn == 1)
+        if (Unit.HasTrait(Traits.RespawnerIII) && (State.GameManager.TacticalMode.currentTurn == 1) && State.GameManager.TacticalMode.attackersTurnCheck == true)
             Unit.AddRespawns(3);
         int sizePenalty = (int)(PredatorComponent?.Fullness ?? 0);
         sizePenalty = (int)(sizePenalty * Unit.TraitBoosts.SpeedLossFromWeightMultiplier);
@@ -1534,7 +1534,7 @@ public class Actor_Unit
             GiveRandomBoost();
 
         Unit.GiveScaledExp(4 * target.Unit.ExpMultiplier, Unit.Level - target.Unit.Level);
-        if (target.Unit.GetStatusEffect(StatusEffectType.Respawns) != null)
+        if (target.Unit.GetStatusEffect(StatusEffectType.Respawns) != null && (target.Unit.HasTrait(Traits.Respawner) || target.Unit.HasTrait(Traits.RespawnerIII)))
         {
             var spawnLoc = TacticalUtilities.GetRandomTileForActor(target);
             if (spawnLoc == null)
@@ -1566,7 +1566,7 @@ public class Actor_Unit
         if (Unit.HasTrait(Traits.TasteForBlood))
             GiveRandomBoost();
         Unit.GiveScaledExp(4 * target.Unit.ExpMultiplier, Unit.Level - target.Unit.Level);
-        if (target.Unit.GetStatusEffect(StatusEffectType.Respawns) != null)
+        if (target.Unit.GetStatusEffect(StatusEffectType.Respawns) != null && (target.Unit.HasTrait(Traits.Respawner) || target.Unit.HasTrait(Traits.RespawnerIII)))
         {
             var spawnLoc = TacticalUtilities.GetRandomTileForActor(target);
             if (spawnLoc == null)

--- a/Assets/Scripts/Entities/Units/Actor_Unit.cs
+++ b/Assets/Scripts/Entities/Units/Actor_Unit.cs
@@ -1544,10 +1544,7 @@ public class Actor_Unit
                 TacticalGraphicalEffects.CreateGenericMagic(spawnLoc, spawnLoc, target, TacticalGraphicalEffects.SpellEffectIcon.Resurrect);
                 target.Unit.Health = target.Unit.MaxHealth;
                 target.Unit.RemoveRespawns();
-                if (target.Unit.Race != Race.Helldivers)
-                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{target.Unit.Name} has respawned!");
-                else
-                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"Reinforcements have arrived!");
+                State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{target.Unit.Name} has respawned!");
         }
     }
 
@@ -1576,10 +1573,8 @@ public class Actor_Unit
                 TacticalGraphicalEffects.CreateGenericMagic(spawnLoc, spawnLoc, target, TacticalGraphicalEffects.SpellEffectIcon.Resurrect);
                 target.Unit.Health = target.Unit.MaxHealth;
                 target.Unit.RemoveRespawns();
-                if (target.Unit.Race != Race.Helldivers)
-                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{target.Unit.Name} has respawned!");
-                else
-                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"Reinforcements have arrived!");
+                State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{target.Unit.Name} has respawned!");
+
         }
     }
 

--- a/Assets/Scripts/Entities/Units/PredatorComponent.cs
+++ b/Assets/Scripts/Entities/Units/PredatorComponent.cs
@@ -1546,10 +1546,7 @@ public class PredatorComponent
                     TacticalGraphicalEffects.CreateGenericMagic(spawnLoc, spawnLoc, preyUnit.Actor, TacticalGraphicalEffects.SpellEffectIcon.Resurrect);
                     preyUnit.Unit.Health = preyUnit.Unit.MaxHealth;
                     preyUnit.Unit.RemoveRespawns();
-                    if (preyUnit.Unit.Race != Race.Helldivers)
-                        State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{preyUnit.Unit.Name} has respawned!");
-                    else
-                        State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"Reinforcements have arrived!");
+                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{preyUnit.Unit.Name} has respawned!");
             }
         }
 

--- a/Assets/Scripts/Entities/Units/PredatorComponent.cs
+++ b/Assets/Scripts/Entities/Units/PredatorComponent.cs
@@ -1432,6 +1432,9 @@ public class PredatorComponent
                 preyUnit.Unit.RemoveTrait(Traits.LuckySurvival);
                 preyUnit.Unit.RemoveTrait(Traits.Reformer);
                 preyUnit.Unit.RemoveTrait(Traits.TheGreatEscape);
+                preyUnit.Unit.RemoveTrait(Traits.DeathCheater);
+                preyUnit.Unit.RemoveTrait(Traits.Respawner);
+                preyUnit.Unit.RemoveTrait(Traits.RespawnerIII);
             }
             else
             {
@@ -1533,7 +1536,7 @@ public class PredatorComponent
             {
                 unit.ApplyStatusEffect(StatusEffectType.Empowered, 1.0f, 5);
             }
-            if (preyUnit.Unit.GetStatusEffect(StatusEffectType.Respawns) != null)
+            if (preyUnit.Unit.GetStatusEffect(StatusEffectType.Respawns) != null && (preyUnit.Unit.HasTrait(Traits.Respawner) || preyUnit.Unit.HasTrait(Traits.RespawnerIII)))
             {
                 var spawnLoc = TacticalUtilities.GetRandomTileForActor(preyUnit.Actor);
                 if (spawnLoc == null)

--- a/Assets/Scripts/Entities/Units/PredatorComponent.cs
+++ b/Assets/Scripts/Entities/Units/PredatorComponent.cs
@@ -1533,6 +1533,21 @@ public class PredatorComponent
             {
                 unit.ApplyStatusEffect(StatusEffectType.Empowered, 1.0f, 5);
             }
+            if (preyUnit.Unit.GetStatusEffect(StatusEffectType.Respawns) != null)
+            {
+                var spawnLoc = TacticalUtilities.GetRandomTileForActor(preyUnit.Actor);
+                if (spawnLoc == null)
+                    State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{preyUnit.Unit.Name} was unable to respawn!");
+                else
+                    TacticalUtilities.Resurrect((spawnLoc),preyUnit.Actor);
+                    TacticalGraphicalEffects.CreateGenericMagic(spawnLoc, spawnLoc, preyUnit.Actor, TacticalGraphicalEffects.SpellEffectIcon.Resurrect);
+                    preyUnit.Unit.Health = preyUnit.Unit.MaxHealth;
+                    preyUnit.Unit.RemoveRespawns();
+                    if (preyUnit.Unit.Race != Race.Helldivers)
+                        State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{preyUnit.Unit.Name} has respawned!");
+                    else
+                        State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"Reinforcements have arrived!");
+            }
         }
 
         if (preyUnit.Unit.IsDead == false)

--- a/Assets/Scripts/Entities/Units/Unit.cs
+++ b/Assets/Scripts/Entities/Units/Unit.cs
@@ -2766,6 +2766,35 @@ internal void SetGenderRandomizeName(Race race, Gender gender)
 
     }
 
+    internal void AddRespawns(int amount)
+    {
+        var resp = GetStatusEffect(StatusEffectType.Respawns);
+        if (resp != null)
+        {
+            resp.Duration += amount;
+            resp.Strength += amount;
+        }
+        else
+        {
+            ApplyStatusEffect(StatusEffectType.Respawns, amount, amount);
+        }
+
+    }
+
+    internal void RemoveRespawns()
+    {
+        var resp = GetStatusEffect(StatusEffectType.Respawns);
+        if (resp != null)
+        {
+            int reduction = 1;
+            resp.Duration -= reduction;
+            resp.Strength -= reduction;
+            if (resp.Duration <= 0)
+                StatusEffects.Remove(resp);
+        }
+
+    }
+
     internal void AddStagger()
     {
         var stag = GetStatusEffect(StatusEffectType.Staggering);
@@ -2811,7 +2840,7 @@ internal void SetGenderRandomizeName(Race race, Gender gender)
             NonFatalDamage((int)effect.Strength, "virus");
         foreach (var eff in StatusEffects.ToList())
         {
-            if (eff.Type == StatusEffectType.BladeDance || eff.Type == StatusEffectType.Tenacious || eff.Type == StatusEffectType.Focus)
+            if (eff.Type == StatusEffectType.Respawns || eff.Type == StatusEffectType.BladeDance || eff.Type == StatusEffectType.Tenacious || eff.Type == StatusEffectType.Focus)
                 continue;
             var actor = TacticalUtilities.Units.Where(s => s.Unit == this).FirstOrDefault();
             var pred = actor.SelfPrey?.Predator;

--- a/Assets/Scripts/Enums/StatusEffectType.cs
+++ b/Assets/Scripts/Enums/StatusEffectType.cs
@@ -64,5 +64,7 @@
     Bloodrite = 32,
     /// <summary>Movement is reduced to 1.</summary>
     Snared = 33,
+    /// <summary>Remaining respawns for the respawner traits.</summary>
+    Respawns = 34,
 }
 

--- a/Assets/Scripts/Enums/Tags.cs
+++ b/Assets/Scripts/Enums/Tags.cs
@@ -382,6 +382,8 @@ public enum Traits
     Respawner = 192,
     /// <summary>Upon getting killed, this unit will be brought back to life within a 6 tile radius of where they were killed once per battle</summary>
     RespawnerIII = 193,
+    /// <summary>Unit has set chance to return to army after dying in battle regardless of outcome. Chance starts at 100% then decreases 10% with each death, bottoming out at 10%.</summary>
+    DeathCheater = 194,
 
 
 

--- a/Assets/Scripts/Enums/Tags.cs
+++ b/Assets/Scripts/Enums/Tags.cs
@@ -378,6 +378,10 @@ public enum Traits
     ManaDynamo = 190,
     /// <summary>Unit deals extra melee or ranged damage at the cost of each attack consuming 6 mana. No bonus is received if mana is under 6</summary>
     WeaponChanneler = 191,
+    /// <summary>Upon getting killed, this unit will be brought back to life within a 6 tile radius of where they were killed once per battle</summary>
+    Respawner = 192,
+    /// <summary>Upon getting killed, this unit will be brought back to life within a 6 tile radius of where they were killed once per battle</summary>
+    RespawnerIII = 193,
 
 
 

--- a/Assets/Scripts/Modes/Tactical/TacticalGraphicalEffects.cs
+++ b/Assets/Scripts/Modes/Tactical/TacticalGraphicalEffects.cs
@@ -120,6 +120,8 @@ static class TacticalGraphicalEffects
             return State.GameManager.SpriteDictionary.SpitterSlug[10];
         else if (actor.Unit.Race == Race.Bats)
             return State.GameManager.SpriteDictionary.Demibats1[132];
+        else if (actor.Unit.Race == Race.Hamsters && (weapon.Graphic == 4 || weapon.Graphic == 6))
+            return State.GameManager.SpriteDictionary.Slimes[17];
         else if (actor.Unit.Race == Race.Panthers)
         {
             if (weapon.Graphic == 4)

--- a/Assets/Scripts/Modes/Tactical/TacticalUtilities.cs
+++ b/Assets/Scripts/Modes/Tactical/TacticalUtilities.cs
@@ -1087,6 +1087,34 @@ static class TacticalUtilities
         UnitPickerUI.gameObject.SetActive(true);
     }
 
+    static internal List<Vec2i> TilesWithinRange(Vec2i location, int range)
+    {
+        List<Vec2i> tile_positions = new List<Vec2i>();
+        int outer_matrix_cursor = 0;
+        for (int y = location.y + range; y >= location.y - range; y--)
+        {
+            int inner_matrix_cursor = 0;
+            for (int x = location.x + range; x >= location.x - range; x--)
+            {
+                if (x < 0 || y < 0 || x > tiles.GetUpperBound(0) || y > tiles.GetUpperBound(1))
+                {
+                    inner_matrix_cursor++;
+                    continue;
+                }
+                tile_positions.Add(new Vec2i(x, y));
+            }
+            outer_matrix_cursor++;
+        }
+        return tile_positions;
+    }
+
+ static internal Vec2i GetRandomTileForActor(Actor_Unit actor)
+ {
+     Vec2i[] tile_positions = TilesWithinRange(actor.Position, 6).Where(tile => OpenTile(tile, actor)).ToArray();
+     if (tile_positions.Length == 0) { return null; }
+     return tile_positions[UnityEngine.Random.Range(0, tile_positions.Length - 1)];
+ }
+
     internal static void Resurrect(Vec2i loc, Actor_Unit target)
     {
         var pred = FindPredator(target);

--- a/Assets/Scripts/Modes/TacticalMode.cs
+++ b/Assets/Scripts/Modes/TacticalMode.cs
@@ -154,6 +154,7 @@ public class TacticalMode : SceneBase
     Spell CurrentSpell;
 
     bool attackersTurn;
+    public bool attackersTurnCheck;
     internal bool IsPlayerTurn;
     internal bool IsPlayerInControl => PseudoTurn || (IsPlayerTurn && RunningFriendlyAI == false && foreignAI == null && !SpectatorMode);
     int activeSide;
@@ -409,6 +410,7 @@ public class TacticalMode : SceneBase
         armies[1] = defender;
         this.village = village;
         attackersTurn = true;
+        attackersTurnCheck = true;
 
         currentTurn = 1;
         corpseCount = 0;
@@ -1209,6 +1211,7 @@ Turns: {currentTurn}
         currentTurn = data.currentTurn;
 
         attackersTurn = data.attackersTurn;
+        attackersTurnCheck = data.attackersTurn;
         IsPlayerTurn = data.isAPlayerTurn;
         activeSide = data.activeSide;
 
@@ -3602,6 +3605,7 @@ Turns: {currentTurn}
         if (attackersTurn)
         {
             attackersTurn = false;
+            attackersTurnCheck = false;
             activeSide = defenderSide;
             currentAI = defenderAI;
             NewTurn();
@@ -3611,6 +3615,7 @@ Turns: {currentTurn}
         else
         {
             attackersTurn = true;
+            attackersTurnCheck = true;
             currentTurn++;
             activeSide = armies[0].Side;
             currentAI = attackerAI;
@@ -3914,7 +3919,9 @@ Turns: {currentTurn}
                 if (actor.Unit.IsDead && actor.Unit.Type != UnitType.Summon &&
                     (actor.Unit.HasTrait(Traits.Eternal) || (actor.Unit.HasTrait(Traits.LuckySurvival) && State.Rand.Next(5) != 0) ||
                     (actor.Unit.HasTrait(Traits.Reformer) && actor.KilledByDigestion) ||
-                    (actor.Unit.HasTrait(Traits.Revenant) && actor.KilledByDigestion == false)
+                    (actor.Unit.HasTrait(Traits.Revenant) && actor.KilledByDigestion == false) ||
+                    (actor.Unit.HasTrait(Traits.DeathCheater) && actor.Unit.TimesKilled <= 9 && (State.Rand.Next(10) >= (actor.Unit.TimesKilled - 1))) ||
+                    (actor.Unit.HasTrait(Traits.DeathCheater) && actor.Unit.TimesKilled >= 10 && (State.Rand.Next(10) == 0))
                     ))
                 {
                     actor.Surrendered = false;

--- a/Assets/Scripts/Utility/Texts/HoveringTooltip.cs
+++ b/Assets/Scripts/Utility/Texts/HoveringTooltip.cs
@@ -601,6 +601,10 @@ public class HoveringTooltip : MonoBehaviour
                 return "Every time digestion progresses, this unit digests one level from each prey inside them, gaining its experience value. If a unit hits level 0 this way, it dies if it was stil alive and cannot be revived.\n(Cheat Trait)";
             case Traits.WeaponChanneler:
                 return "Unit deals extra melee or ranged damage at the cost of each srtike consuming 6 mana. No bonus is received if mana is under 6.";
+            case Traits.Respawner:
+                return "Upon getting killed, this unit will be brought back to life within a 6 tile radius of where they were killed once per battle.";
+            case Traits.RespawnerIII:
+                return "Upon getting killed, this unit will be brought back to life within a 6 tile radius of where they were killed 3 times per battle!";
         }  
         return "<b>This trait needs a tooltip!</b>";
     }

--- a/Assets/Scripts/Utility/Texts/HoveringTooltip.cs
+++ b/Assets/Scripts/Utility/Texts/HoveringTooltip.cs
@@ -598,13 +598,15 @@ public class HoveringTooltip : MonoBehaviour
             case Traits.Unflinching:
                 return "Unit's BladeDance, Tenacity, and Focus stack loss is reduced by if stacks are below 10% current HP.";
             case Traits.Annihilation:
-                return "Every time digestion progresses, this unit digests one level from each prey inside them, gaining its experience value. If a unit hits level 0 this way, it dies if it was stil alive and cannot be revived.\n(Cheat Trait)";
+                return "Every time digestion progresses, this unit digests one level from each prey inside them, gaining its experience value. If a unit hits level 0 this way, it dies if it was still alive and cannot be revived.\n(Cheat Trait)";
             case Traits.WeaponChanneler:
                 return "Unit deals extra melee or ranged damage at the cost of each srtike consuming 6 mana. No bonus is received if mana is under 6.";
             case Traits.Respawner:
                 return "Upon getting killed, this unit will be brought back to life within a 6 tile radius of where they were killed once per battle.";
             case Traits.RespawnerIII:
                 return "Upon getting killed, this unit will be brought back to life within a 6 tile radius of where they were killed 3 times per battle!";
+            case Traits.DeathCheater:
+                return "Unit has set chance to return to army after dying in battle regardless of outcome. Chance starts at 100% then decreases 10% with each death, bottoms out at 10%";
         }  
         return "<b>This trait needs a tooltip!</b>";
     }


### PR DESCRIPTION
DeathCheater:  Unit has set chance to return to army after dying in battle regardless of outcome. Chance starts at 100% then decreases 10% with each death, bottoming out at 10%.
Respawner: At start of combat unit is given as set amount of "Respawns" depending on which version of the trait they have; When the unit is killed regardless of method they will respawn within a 6 tile radius. Units will use all of their respawns before auto-surrendering.
Fixes:
Hamsters no longer throw axes that turn into arrows when equipped with a Tier1 ranged weapon
Flame Wave and Fire Bomb now actually do fire damage!