### PR TITLE
Empire traits menu, prey's hex & upkeep fix

### DIFF
--- a/Assets/Prefabs/UI/EditEmpireTraits.prefab
+++ b/Assets/Prefabs/UI/EditEmpireTraits.prefab
@@ -1,0 +1,774 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1397228045686626
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 224473214305485076}
+  - component: {fileID: 222483917249669984}
+  - component: {fileID: 114294734701136542}
+  m_Layer: 0
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &224473214305485076
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1397228045686626}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224343354455353904}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &222483917249669984
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1397228045686626}
+  m_CullTransparentMesh: 0
+--- !u!114 &114294734701136542
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1397228045686626}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 2
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Enter text...
+--- !u!1 &1723205296601316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 224519959969845190}
+  - component: {fileID: 4632435098033429518}
+  m_Layer: 0
+  m_Name: EditEmpireTraits
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &224519959969845190
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723205296601316}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224315921037566010}
+  - {fileID: 2701798280499936411}
+  - {fileID: 224343354455353904}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &4632435098033429518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723205296601316}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e52dea7eb8628c047a3b2ca023886c3b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  EmpTraits: {fileID: 114936042968055832}
+  Name: {fileID: 1234366141887129558}
+--- !u!1 &1748661321691822
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 224343354455353904}
+  - component: {fileID: 222232323955836380}
+  - component: {fileID: 114674583347405886}
+  - component: {fileID: 114936042968055832}
+  - component: {fileID: 114137007897867222}
+  m_Layer: 0
+  m_Name: EmpireTraits
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &224343354455353904
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1748661321691822}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9999984, y: 0.9999984, z: 0}
+  m_Children:
+  - {fileID: 224473214305485076}
+  - {fileID: 224487059824202304}
+  m_Father: {fileID: 224519959969845190}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 650, y: 0}
+  m_SizeDelta: {x: 700, y: 45}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &222232323955836380
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1748661321691822}
+  m_CullTransparentMesh: 0
+--- !u!114 &114674583347405886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1748661321691822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!114 &114936042968055832
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1748661321691822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 575553740, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 114674583347405886}
+  m_TextComponent: {fileID: 114761271279353006}
+  m_Placeholder: {fileID: 114294734701136542}
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_CharacterValidation: 0
+  m_CharacterLimit: 0
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.InputField+SubmitEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.InputField+OnChangeEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+--- !u!114 &114137007897867222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1748661321691822}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2899127c6b4de494aae323cecb1b103f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 7
+--- !u!1 &1877112363828244
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 224487059824202304}
+  - component: {fileID: 222284851092938412}
+  - component: {fileID: 114761271279353006}
+  - component: {fileID: 3438128352362920065}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &224487059824202304
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877112363828244}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224343354455353904}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -7}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &222284851092938412
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877112363828244}
+  m_CullTransparentMesh: 0
+--- !u!114 &114761271279353006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877112363828244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!114 &3438128352362920065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877112363828244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2899127c6b4de494aae323cecb1b103f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 1
+--- !u!1 &1922748409372162
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 224315921037566010}
+  - component: {fileID: 222297642919275742}
+  - component: {fileID: 114045540255595906}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &224315921037566010
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922748409372162}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224519959969845190}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 4, y: 0}
+  m_SizeDelta: {x: 132, y: 40}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &222297642919275742
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922748409372162}
+  m_CullTransparentMesh: 0
+--- !u!114 &114045540255595906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922748409372162}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Cats
+--- !u!1 &1959731554434140288
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2701798280499936411}
+  - component: {fileID: 2460537113135883899}
+  - component: {fileID: 1816796799095142857}
+  - component: {fileID: 1234366141887129558}
+  - component: {fileID: 8939905809906642189}
+  m_Layer: 0
+  m_Name: EmpireName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2701798280499936411
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959731554434140288}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0}
+  m_Children:
+  - {fileID: 4653163876182196542}
+  - {fileID: 467837924450175092}
+  m_Father: {fileID: 224519959969845190}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 4, y: 0}
+  m_SizeDelta: {x: 525, y: 45}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &2460537113135883899
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959731554434140288}
+  m_CullTransparentMesh: 0
+--- !u!114 &1816796799095142857
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959731554434140288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!114 &1234366141887129558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959731554434140288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 575553740, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1816796799095142857}
+  m_TextComponent: {fileID: 5796055306778183494}
+  m_Placeholder: {fileID: 5328269579204736002}
+  m_ContentType: 0
+  m_InputType: 0
+  m_AsteriskChar: 42
+  m_KeyboardType: 0
+  m_LineType: 0
+  m_HideMobileInput: 0
+  m_CharacterValidation: 0
+  m_CharacterLimit: 75
+  m_OnEndEdit:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.InputField+SubmitEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.InputField+OnChangeEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  m_CaretColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_CustomCaretColor: 0
+  m_SelectionColor: {r: 0.65882355, g: 0.80784315, b: 1, a: 0.7529412}
+  m_Text: 
+  m_CaretBlinkRate: 0.85
+  m_CaretWidth: 1
+  m_ReadOnly: 0
+--- !u!114 &8939905809906642189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959731554434140288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2899127c6b4de494aae323cecb1b103f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 7
+--- !u!1 &7902701752998117007
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 467837924450175092}
+  - component: {fileID: 2207922374750757806}
+  - component: {fileID: 5796055306778183494}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &467837924450175092
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7902701752998117007}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2701798280499936411}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -7}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2207922374750757806
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7902701752998117007}
+  m_CullTransparentMesh: 0
+--- !u!114 &5796055306778183494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7902701752998117007}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!1 &8619532374425694004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4653163876182196542}
+  - component: {fileID: 5999294447058679056}
+  - component: {fileID: 5328269579204736002}
+  m_Layer: 0
+  m_Name: Placeholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4653163876182196542
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8619532374425694004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2701798280499936411}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: -20, y: -13}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5999294447058679056
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8619532374425694004}
+  m_CullTransparentMesh: 0
+--- !u!114 &5328269579204736002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8619532374425694004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 0.5}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 2
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Enter text...

--- a/Assets/Prefabs/UI/EditEmpireTraits.prefab.meta
+++ b/Assets/Prefabs/UI/EditEmpireTraits.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8bc3f26d89a676f4e9fad5108ba9b62f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/State.cs
+++ b/Assets/Scripts/Core/State.cs
@@ -1036,14 +1036,14 @@ public static class State
                 {
                     foreach (Empire empire in World.AllActiveEmpires)
                     {
-                        empire.LoadFix(); //Compatibility Temporary fix to bridge the gap between versions
+                        empire.LoadFix(); //Compatibility Temporary fix to bridge the gap between versions; add your null checks here in Empire.cs
                     }
                 }
                 else
                 {
                     foreach (Empire empire in World.MainEmpires)
                     {
-                        empire.LoadFix(); //Compatibility Temporary fix to bridge the gap between versions
+                        empire.LoadFix(); //Compatibility Temporary fix to bridge the gap between versions; add your null checks here in Empire.cs
                     }
                 }
 
@@ -1053,7 +1053,7 @@ public static class State
                     {
                         foreach (Unit unit in army.Units)
                         {
-                            unit.ReloadTraits();
+                            unit.ReloadTraits();//Add unit-based null checks for newly added internal(s) or protected(s) to this void in Unit.cs so that on loading an older version saved units will recive them
                         }
                     }
                 }

--- a/Assets/Scripts/Entities/Empire.cs
+++ b/Assets/Scripts/Entities/Empire.cs
@@ -269,10 +269,10 @@ public class Empire
         }
         if (Side < 50)
         {
+            int upkeep = GetUpkeep();
+            Income = Income - (int)(upkeep - (upkeep * 0.125f * AcademyResearch.GetValueFromEmpire(this, AcademyResearchType.GoldMineIncome)));
             for (int i = 0; i < Armies.Count; i++)
             {
-                int upkeep = GetUpkeep();
-                Income = Income - (int)(upkeep - (upkeep * 0.125f * AcademyResearch.GetValueFromEmpire(this, AcademyResearchType.GoldMineIncome)));
                 if (AddToStats)
                 {
                     State.World.Stats.CollectedGold(Armies[i].Units.Count * 2, Armies[i].Side);

--- a/Assets/Scripts/Entities/Empire.cs
+++ b/Assets/Scripts/Entities/Empire.cs
@@ -31,6 +31,8 @@ public class Empire
     public List<Army> Armies;
     [OdinSerialize]
     public List<ConstructibleBuilding> Buildings;
+    [OdinSerialize]
+    public List<Traits> EmpTraits;
 
     [OdinSerialize]
     public int MaxArmySize;
@@ -190,6 +192,7 @@ public class Empire
         OrigMaxGarrisonSize = args.maxGarrisonSize;
         Armies = new List<Army>();
         Buildings = new List<ConstructibleBuilding>();
+        EmpTraits = new List<Traits>();
         InitBuildLimit();
         OwnedTiles = new List<Vec2i>();
         AcademyResearchCompleted = new Dictionary<AcademyResearchType, int>();
@@ -256,6 +259,8 @@ public class Empire
             AcademyResearchCompleted = new Dictionary<AcademyResearchType, int>();
         if (EmpirePotions == null)
             EmpirePotions = new Dictionary<LaboratoryPotion, int>();
+        if (EmpTraits == null)
+            EmpTraits = new List<Traits>();
     }
 
     internal void CheckEvent()

--- a/Assets/Scripts/Entities/Empire.cs
+++ b/Assets/Scripts/Entities/Empire.cs
@@ -234,8 +234,20 @@ public class Empire
 
     }
 
-    public void LoadFix()
+    public void LoadFix()//Add empire-based null checks for newly added internal(s) or protected(s) and the like to this void so that on loading an older version empires will recive them
     {
+        if (Buildings == null)
+        Buildings = new List<ConstructibleBuilding>();
+        if (EmpireBuildingLimit == null)
+        InitBuildLimit();
+        if (OwnedTiles == null)
+        OwnedTiles = new List<Vec2i>();
+        if (constructionResources == null)
+        {
+            constructionResources = new ConstructionResources();
+            constructionResources.Reset();
+            constructionResources.SetResources(10, 10, 10, 10, 10, 10);
+        }
         if (Reports == null)
             Reports = new List<StrategicReport>();
         if (EventHappened == null)

--- a/Assets/Scripts/Entities/Items/ItemRepository.cs
+++ b/Assets/Scripts/Entities/Items/ItemRepository.cs
@@ -132,6 +132,7 @@ public class ItemRepository
             new SpellBook("Speed Book", "Allows the casting of Speed", 30, 1, SpellTypes.Speed),
             new SpellBook("Valor Book", "Allows the casting of Valor", 30, 1, SpellTypes.Valor),
             new SpellBook("Predation Book", "Allows the casting of Predation", 30, 1, SpellTypes.Predation),
+            new SpellBook("Prey's Hex Book", "Allows the casting of Prey's Hex", 30, 1, SpellTypes.PreysHex),
             new SpellBook("Ice Blast Book", "Allows the casting of Ice Blast", 60, 2, SpellTypes.IceBlast),
             new SpellBook("Pyre Book", "Allows the casting of Pyre", 60, 2, SpellTypes.Pyre),
             new SpellBook("CrossShock Book", "Allows the casting of Cross Shock", 60, 2, SpellTypes.CrossShock),

--- a/Assets/Scripts/Entities/Spells/SpellList.cs
+++ b/Assets/Scripts/Entities/Spells/SpellList.cs
@@ -626,7 +626,7 @@ static class SpellList
             Range = new Range(5),
             Tier = 1,
             Resistable = true,
-            ResistanceMult = 1.10f,
+            ResistanceMult = 0.90f,
             Damage = (a, t) => 1 + a.Unit.GetStat(Stat.Mind) / 25,
             OnExecute = (a, t) =>
             {

--- a/Assets/Scripts/Entities/Spells/SpellList.cs
+++ b/Assets/Scripts/Entities/Spells/SpellList.cs
@@ -75,6 +75,7 @@ static class SpellList
     static internal readonly Spell CaptureNet;
     static internal readonly Spell SummonDoppelganger;
     static internal readonly Spell SummonSpawn;
+    static internal readonly DamageSpell PreysHex;
 
     //Quicksand
     static internal readonly StatusSpell PreysCurse;
@@ -179,10 +180,12 @@ static class SpellList
             Damage = (a, t) => 5 + a.Unit.GetStat(Stat.Mind) / 10,
             OnExecute = (a, t) =>
             {
+                int curr = t.Unit.Health;
                 a.CastOffensiveSpell(Icicle, t);
                 TacticalGraphicalEffects.CreateIcicle(a.Position, t.Position, t);
                 State.GameManager.SoundManager.PlaySpellCast(PowerBolt, a);
-                if (State.Rand.Next(3) == 0)
+                bool didSpellHit = curr != t.Unit.Health;
+                if (didSpellHit && State.Rand.Next(3) == 0)
                 {
                     State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"{t.Unit.Name} Was frozen solid!");
                     t.Unit.ApplyStatusEffect(StatusEffectType.Frozen, 1f, 2);
@@ -612,6 +615,40 @@ static class SpellList
             },
         };
         SpellDict[SpellTypes.Trance] = Trance;
+
+        PreysHex = new DamageSpell()
+        {
+            Name = "Prey's Hex",
+            Id = "preysHex",
+            SpellType = SpellTypes.PreysHex,
+            Description = "A hex that causes immense nausea and dizziness forcing a predator to release one of their prey, deals minimal damage.",
+            AcceptibleTargets = new List<AbilityTargets>() { AbilityTargets.Enemy },
+            Range = new Range(5),
+            Tier = 1,
+            Resistable = true,
+            ResistanceMult = 1.10f,
+            Damage = (a, t) => 1 + a.Unit.GetStat(Stat.Mind) / 25,
+            OnExecute = (a, t) =>
+            {
+                int curr = t.Unit.Health;
+                a.CastOffensiveSpell(PreysHex, t);
+                bool didSpellHit = curr != t.Unit.Health;
+                if (didSpellHit)
+                {
+                    if (t.PredatorComponent.AlivePrey == 0)
+                    {
+                        State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"<b>{t.Unit.Name}</b> is dizzy from the hex but has no prey to release.");
+                        TacticalGraphicalEffects.CreateGenericMagic(a.Position, t.Position, t, TacticalGraphicalEffects.SpellEffectIcon.Poison);
+                    }
+                    else
+                    {
+                        t.PredatorComponent.FreeRandomPreyNow();
+                        TacticalGraphicalEffects.CreateGenericMagic(a.Position, t.Position, t, TacticalGraphicalEffects.SpellEffectIcon.Poison);
+                    }
+                }
+            },
+        };
+        SpellDict[SpellTypes.PreysHex] = PreysHex;
 
         FlameWave = new DamageSpell()
         {

--- a/Assets/Scripts/Entities/Units/PredatorComponent.cs
+++ b/Assets/Scripts/Entities/Units/PredatorComponent.cs
@@ -805,6 +805,23 @@ public class PredatorComponent
         return target;
     }
 
+    public void FreeRandomPreyNow()//Code for prey's hex spell. Selects a random living prey that a pred has consumed and releases them, prioritses hostiles units to the pred.
+    {
+        List<Prey> preyUnits = new List<Prey>();
+        preyUnits.AddRange(prey);
+        //var alives = preyUnits.Where(s => s.Unit.IsDead == false).ToArray();
+        var alives = preyUnits.Where(s => s.Unit.IsDead == false && TacticalUtilities.TreatAsHostile(actor, s.Actor)).ToArray();
+        if (alives.Length == 0)
+            alives = preyUnits.Where(s => s.Unit.IsDead == false).ToArray();
+        var target = alives[State.Rand.Next(alives.Length)];
+        State.GameManager.TacticalMode.TacticalStats.RegisterFreed(unit.Side);
+        if (State.Rand.Next(2) == 0)
+            State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"<b>{actor.Unit.Name}</b> succumbs to the hex and releases <b>{target.Unit.Name}</b>.");
+        else
+            State.GameManager.TacticalMode.Log.RegisterMiscellaneous($"The effects from the hex overwhelms <b>{actor.Unit.Name}</b> causing {LogUtilities.GPPHim(actor.Unit)} to release <b>{target.Unit.Name}</b>.");
+        target.Predator.PredatorComponent.FreePrey(target, true);
+    }
+
     internal void FreeGreatEscapePrey(Prey preyUnit)
     {
         TacticalUtilities.Log.LogGreatEscapeFlee(unit, preyUnit.Unit, Location(preyUnit));

--- a/Assets/Scripts/Entities/Units/Unit.cs
+++ b/Assets/Scripts/Entities/Units/Unit.cs
@@ -2228,9 +2228,11 @@ internal void SetGenderRandomizeName(Race race, Gender gender)
         }
     }
 
-    internal void ReloadTraits()
+    internal void ReloadTraits()//Add unit-based null checks for newly added internal(s) or protected(s) to this void so that on loading an older version saves, units will recive them
     {
         Tags = new List<Traits>();
+        if (AllConditionalTraits == null)
+            AllConditionalTraits = new Dictionary<ConditionalTraitContainer, bool>();
         if (Config.RaceTraitsEnabled)
             Tags.AddRange(State.RaceSettings.GetRaceTraits(HiddenUnit.Race));
         if (HiddenUnit.HasBreasts && HiddenUnit.HasDick == false)

--- a/Assets/Scripts/Entities/Units/Unit.cs
+++ b/Assets/Scripts/Entities/Units/Unit.cs
@@ -2275,6 +2275,12 @@ internal void SetGenderRandomizeName(Race race, Gender gender)
             Tags.AddRange(SharedTraits);
         if (PersistentSharedTraits != null)
             Tags.AddRange(PersistentSharedTraits);
+        if (!State.GameManager.PureTactical && (State.GameManager.CurrentScene == State.GameManager.StrategyMode || State.GameManager.CurrentScene == State.GameManager.TacticalMode))
+        {
+            if (State.World.GetEmpireOfSide(HiddenUnit.Side) == null) {}//Execption fix due to how saves are loaded
+            else if (State.World.GetEmpireOfSide(HiddenUnit.Side).EmpTraits != null)
+                Tags.AddRange(State.World.GetEmpireOfSide(HiddenUnit.Side).EmpTraits);
+        }
         if (RemovedTraits != null)
         {
             foreach (Traits trait in RemovedTraits)

--- a/Assets/Scripts/Enums/SpellTypes.cs
+++ b/Assets/Scripts/Enums/SpellTypes.cs
@@ -52,6 +52,7 @@
     CrossShock = 44,
     JoltCrash = 45,
     ArcBolt = 46,
+    PreysHex = 47,
 
     AlraunePuff = 70,
     Web = 71,

--- a/Assets/Scripts/Modes/Tactical/Log/StoredLogTexts.cs
+++ b/Assets/Scripts/Modes/Tactical/Log/StoredLogTexts.cs
@@ -3024,7 +3024,7 @@ static class StoredLogTexts
             new EventString((i) => $"<b>{i.Unit.Name}</b> catches <b>{i.Target.Name}</b> off guard and crams {GPPHim(i.Target)} down {GPPHis(i.Unit)} tail.", priority: 8),
             new EventString((i) => $"<b>{i.Unit.Name}</b> slurps up <b>{i.Target.Name}</b> with {GPPHis(i.Unit)} tail!", priority: 8),
             new EventString((i) => $"<b>{i.Unit.Name}</b> yanks <b>{i.Target.Name}</b> into {GPPHis(i.Unit)} hungry tail maw.", priority: 8),
-            new EventString((i) => $"<b>{ApostrophizeWithOrWithoutS(i.Target.Name)}</b> struggles are for naught as {GPPHe(i.Target)} vanishe{SIfSingular(i.Target)} into <b>{ApostrophizeWithOrWithoutS(i.Unit.Name)}</b> ravenous tail.", priority: 8),
+            new EventString((i) => $"<b>{ApostrophizeWithOrWithoutS(i.Target.Name)}</b> struggles are for naught as {GetRandomStringFrom($"{GPPHe(i.Target)} vanish{EsIfSingular(i.Target)}", $"{GPPHe(i.Target)} vanish{EsIfSingular(i.Target)}", $"{GPPHe(i.Target)} vanish{EsIfSingular(i.Target)}", $"{GPPHe(i.Target)} vanish{EsIfSingular(i.Target)}", "they vanishe")} into <b>{ApostrophizeWithOrWithoutS(i.Unit.Name)}</b> ravenous tail.", priority: 8),
 
             new EventString((i) => $"<b>{i.Unit.Name}</b> blows <b>{i.Target.Name}</b> a kiss before sliding the tip of {GPPHis(i.Unit)} tail over <b>{ApostrophizeWithOrWithoutS(i.Target.Name)}</b> head and slurping the {GetPreyDesc(i.Target)} {GetRaceDescSingl(i.Target)} up!", actorRace: Race.Succubi, priority: 9),
             new EventString((i) => $"<b>{i.Unit.Name}</b> distracts <b>{i.Target.Name}</b> with a tight sensual hug, just enough for {GPPHis(i.Unit)} to suck <b>{i.Target.Name}</b> into {GPPHis(i.Unit)} tail!", actorRace: Race.Succubi, priority: 9),

--- a/Assets/Scripts/Races/Graphics/MainRaces/Gnolls.cs
+++ b/Assets/Scripts/Races/Graphics/MainRaces/Gnolls.cs
@@ -41,18 +41,18 @@ class Gnolls : DefaultRaceData
         Balls = new SpriteExtraInfo(3, BallsSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Critical damage
         Dick = new SpriteExtraInfo(4, DickSprite, null, null); // Strange cylindrical object
         Belly = new SpriteExtraInfo(5, null, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Snuggle into it
-        Breasts = new SpriteExtraInfo(6, BreastsSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Left Booba
-        SecondaryBreasts = new SpriteExtraInfo(6, SecondaryBreastsSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Right Booba
-        Head = new SpriteExtraInfo(10, HeadSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Yes, please! (sorry...)
-        BodyAccent = new SpriteExtraInfo(11, BodyAccentSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Face Fur Pattern
-        Mouth = new SpriteExtraInfo(12, MouthSprite, null, null);
-        Eyes = new SpriteExtraInfo(13, EyesSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.EyeColor, s.Unit.EyeColor)); // Iris
-        SecondaryEyes = new SpriteExtraInfo(14, EyesSecondarySprite, null, null); // Sclera
-        Hair = new SpriteExtraInfo(15, HairSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.HairColor)); // Main Hair
-        BodyAccent2 = new SpriteExtraInfo(16, BodyAccentSprite2, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Outer Ear Fur
-        BodyAccent3 = new SpriteExtraInfo(17, BodyAccentSprite3, null, null); // Inner Ear
-        Hair2 = new SpriteExtraInfo(18, HairSprite2, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.HairColor)); // Front Hair
-        Weapon = new SpriteExtraInfo(20, WeaponSprite, WhiteColored);
+        Breasts = new SpriteExtraInfo(13, BreastsSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Left Booba
+        SecondaryBreasts = new SpriteExtraInfo(13, SecondaryBreastsSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Right Booba
+        Head = new SpriteExtraInfo(15, HeadSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Yes, please! (sorry...)
+        BodyAccent = new SpriteExtraInfo(16, BodyAccentSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Face Fur Pattern
+        Mouth = new SpriteExtraInfo(17, MouthSprite, null, null);
+        Eyes = new SpriteExtraInfo(18, EyesSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.EyeColor, s.Unit.EyeColor)); // Iris
+        SecondaryEyes = new SpriteExtraInfo(19, EyesSecondarySprite, null, null); // Sclera
+        Hair = new SpriteExtraInfo(20, HairSprite, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.HairColor)); // Main Hair
+        BodyAccent2 = new SpriteExtraInfo(21, BodyAccentSprite2, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.SkinColor)); // Outer Ear Fur
+        BodyAccent3 = new SpriteExtraInfo(22, BodyAccentSprite3, null, null); // Inner Ear
+        Hair2 = new SpriteExtraInfo(23, HairSprite2, null, (s) => ColorPaletteMap.GetPalette(ColorPaletteMap.SwapType.GnollSkin, s.Unit.HairColor)); // Front Hair
+        Weapon = new SpriteExtraInfo(12, WeaponSprite, WhiteColored);
 
         LeaderClothes = new GnollLeader();
         Rags = new GnollRags();
@@ -836,7 +836,7 @@ class Gnolls : DefaultRaceData
             femaleOnly = true;
             coversBreasts = false;
             blocksDick = false;
-            clothing1 = new SpriteExtraInfo(7, null, null);
+            clothing1 = new SpriteExtraInfo(14, null, null);
             Type = 1524;
             DiscardUsesPalettes = true;
         }
@@ -871,7 +871,7 @@ class Gnolls : DefaultRaceData
             femaleOnly = true;
             coversBreasts = false;
             blocksDick = false;
-            clothing1 = new SpriteExtraInfo(7, null, null);
+            clothing1 = new SpriteExtraInfo(14, null, null);
             Type = 1534;
             DiscardUsesPalettes = true;
         }
@@ -906,7 +906,7 @@ class Gnolls : DefaultRaceData
             femaleOnly = true;
             coversBreasts = false;
             blocksDick = false;
-            clothing1 = new SpriteExtraInfo(7, null, null);
+            clothing1 = new SpriteExtraInfo(14, null, null);
             Type = 1544;
             DiscardUsesPalettes = true;
         }
@@ -941,8 +941,8 @@ class Gnolls : DefaultRaceData
             femaleOnly = true;
             coversBreasts = false;
             blocksDick = false;
-            clothing1 = new SpriteExtraInfo(7, null, null);
-            clothing2 = new SpriteExtraInfo(8, null, WhiteColored);
+            clothing1 = new SpriteExtraInfo(14, null, null);
+            clothing2 = new SpriteExtraInfo(15, null, WhiteColored);
             Type = 1555;
             DiscardUsesPalettes = true;
         }
@@ -980,8 +980,8 @@ class Gnolls : DefaultRaceData
             femaleOnly = true;
             coversBreasts = false;
             blocksDick = false;
-            clothing1 = new SpriteExtraInfo(7, null, null);
-            clothing2 = new SpriteExtraInfo(8, null, WhiteColored);
+            clothing1 = new SpriteExtraInfo(14, null, null);
+            clothing2 = new SpriteExtraInfo(15, null, WhiteColored);
             Type = 1574;
             DiscardUsesPalettes = true;
         }
@@ -1020,7 +1020,7 @@ class Gnolls : DefaultRaceData
             femaleOnly = true;
             coversBreasts = false;
             blocksDick = false;
-            clothing1 = new SpriteExtraInfo(7, null, null);
+            clothing1 = new SpriteExtraInfo(14, null, null);
             Type = 1588;
             DiscardUsesPalettes = true;
         }
@@ -1056,7 +1056,7 @@ class Gnolls : DefaultRaceData
             femaleOnly = true;
             coversBreasts = false;
             blocksDick = false;
-            clothing1 = new SpriteExtraInfo(7, null, null);
+            clothing1 = new SpriteExtraInfo(14, null, null);
             Type = 1544;
             DiscardUsesPalettes = true;
         }
@@ -1141,7 +1141,7 @@ class Gnolls : DefaultRaceData
         {
             coversBreasts = false;
             OccupiesAllSlots = true;
-            clothing1 = new SpriteExtraInfo(18, null, null);
+            clothing1 = new SpriteExtraInfo(14, null, null);
             clothing2 = new SpriteExtraInfo(7, null, null);
             FixedColor = true;
         }
@@ -1179,9 +1179,9 @@ class Gnolls : DefaultRaceData
             coversBreasts = false;
             OccupiesAllSlots = true;
             FixedColor = true;
-            clothing1 = new SpriteExtraInfo(18, null, WhiteColored);
+            clothing1 = new SpriteExtraInfo(14, null, WhiteColored);
             clothing2 = new SpriteExtraInfo(12, null, WhiteColored);
-            clothing3 = new SpriteExtraInfo(19, null, WhiteColored);
+            clothing3 = new SpriteExtraInfo(11, null, WhiteColored);
         }
 
         public override void Configure(CompleteSprite sprite, Actor_Unit actor)
@@ -1271,7 +1271,7 @@ class Gnolls : DefaultRaceData
             Type = 207;
             OccupiesAllSlots = true;
             FixedColor = true;
-            clothing1 = new SpriteExtraInfo(7, null, WhiteColored);
+            clothing1 = new SpriteExtraInfo(14, null, WhiteColored);
             clothing2 = new SpriteExtraInfo(8, null, WhiteColored);
         }
 
@@ -1306,7 +1306,7 @@ class Gnolls : DefaultRaceData
             coversBreasts = false;
             OccupiesAllSlots = true;
             FixedColor = true;
-            clothing1 = new SpriteExtraInfo(7, null, WhiteColored);
+            clothing1 = new SpriteExtraInfo(14, null, WhiteColored);
             clothing2 = new SpriteExtraInfo(8, null, WhiteColored);
         }
 

--- a/Assets/Scripts/Subwindows/EmpireSettings.cs
+++ b/Assets/Scripts/Subwindows/EmpireSettings.cs
@@ -1,0 +1,69 @@
+﻿using LegacyAI;
+using System;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class EmpireSettings : MonoBehaviour
+{
+    public GameObject SetEmpireTraitsPrefab;
+    public Transform folder;
+    EditEmpireTraitsUI[] Empires;
+
+    public void Open()
+    {
+        if (Empires != null)
+        {
+            foreach (var item in Empires)
+            {
+                Destroy(item.gameObject);
+            }
+        }
+        Empires = new EditEmpireTraitsUI[State.World.MainEmpires.Count];
+        for (int i = 0; i < Empires.Length; i++)
+        {
+            Empires[i] = Instantiate(SetEmpireTraitsPrefab, folder).GetComponent<EditEmpireTraitsUI>();
+            Empires[i].Name.text = State.World.MainEmpires[i].Name.ToString();
+            Empires[i].EmpTraits.text = RaceEditorPanel.TraitListToText(State.World.MainEmpires[i].EmpTraits).ToString();
+            if (State.World.MainEmpires[i].KnockedOut || State.World.MainEmpires[i].Side > 600)
+                Empires[i].gameObject.SetActive(false);
+        }
+        RelationsManager.ResetMonsterRelations();
+    }
+
+    public static Color GetLighterColor(Color color)
+    {
+        color.r /= .6f;
+        color.g /= .6f;
+        color.b /= .6f;
+        return color;
+    }
+
+    public void ExitAndSave()
+    {
+        for (int i = 0; i < Empires.Length; i++)
+        {
+            if (State.World.MainEmpires[i].Side > 500)
+                continue;
+            State.World.MainEmpires[i].EmpTraits = RaceEditorPanel.TextToTraitList(Empires[i].EmpTraits.text);
+            State.World.MainEmpires[i].Name = Empires[i].Name.text;
+        }
+        if (Config.Diplomacy == false)
+            RelationsManager.ResetRelationTypes();
+        State.World.RefreshTurnOrder();
+        State.World.UpdateBanditLimits();
+        State.GameManager.StrategyMode?.CheckIfOnlyAIPlayers();
+        gameObject.SetActive(false);
+        foreach (Unit unit in StrategicUtilities.GetAllUnits())
+            {
+                unit.ReloadTraits(); //Add those traits right away!
+            }
+    }
+
+    public void ExitWithoutSaving()
+    {
+        gameObject.SetActive(false);
+    }
+
+}

--- a/Assets/Scripts/Subwindows/EmpireSettings.cs.meta
+++ b/Assets/Scripts/Subwindows/EmpireSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8a43248d627aba4383a25414b701623
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Subwindows/GameMenu.cs
+++ b/Assets/Scripts/Subwindows/GameMenu.cs
@@ -6,6 +6,7 @@ public class GameMenu : MonoBehaviour
     public Options Options;
     public GameObject UIPanel;
     public WorldSettings WorldSettingsUI;
+    public EmpireSettings EmpireSettingsUI;
 
     public SaveLoad SaveLoadScreen;
     public CheatMenu CheatMenu;
@@ -20,6 +21,7 @@ public class GameMenu : MonoBehaviour
     public Button SaveLoadButton;
     public Button OpenMapEditorButton;
     public Button WorldSettingsButton;
+    public Button EmpireSettingsButton;
 
     public GameObject HelpScreen;
 
@@ -31,11 +33,13 @@ public class GameMenu : MonoBehaviour
         {
             OpenMapEditorButton.interactable = false;
             WorldSettingsButton.interactable = false;
+            EmpireSettingsButton.interactable = false;
         }
         else
         {
             OpenMapEditorButton.interactable = true;
             WorldSettingsButton.interactable = true;
+            EmpireSettingsButton.interactable = true;
         }
         SaveLoadButton.interactable = State.TutorialMode == false;
     }
@@ -95,6 +99,18 @@ public class GameMenu : MonoBehaviour
     {
         HelpUI.GenerateButtonsIfNeeded();
         HelpScreen.SetActive(true);
+    }
+
+    public void OpenEmpireTraits()
+    {
+        if (State.World.MainEmpires == null)
+        {
+            State.GameManager.CreateMessageBox("No world is currently loaded, you're in a pure tactical game");
+            return;
+        }
+
+        EmpireSettingsUI.gameObject.SetActive(true);
+        EmpireSettingsUI.Open();
     }
 
     public void CloseHelp()

--- a/Assets/Scripts/UI/Connectors/EditEmpireTraitsUI.cs
+++ b/Assets/Scripts/UI/Connectors/EditEmpireTraitsUI.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+public class EditEmpireTraitsUI : MonoBehaviour
+{
+    public InputField EmpTraits;
+    public InputField Name;
+
+}

--- a/Assets/Scripts/UI/Connectors/EditEmpireTraitsUI.cs.meta
+++ b/Assets/Scripts/UI/Connectors/EditEmpireTraitsUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e52dea7eb8628c047a3b2ca023886c3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/RightClickMenu.cs
+++ b/Assets/Scripts/UI/RightClickMenu.cs
@@ -585,6 +585,11 @@ public class RightClickMenu : MonoBehaviour
                     PounceButtons[currentButton].GetComponentInChildren<Text>().text = $"Too bulky to {targetedAction.Name}";
                     PounceButtons[currentButton].interactable = false;
                 }
+                if (data.Actor.Unit.Race == Race.Ki && data.Target.Unit.Race != Race.Selicia && type == SpecialAction.CockVore)
+                {
+                    PounceButtons[currentButton].GetComponentInChildren<Text>().text = $"Ki's cock is for Selicia only";
+                    PounceButtons[currentButton].interactable = false;
+                }
                 else if (data.Actor.BodySize() < data.Target.BodySize() * 3 && data.Actor.Unit.HasTrait(Traits.TightNethers) && (type == SpecialAction.CockVore || type == SpecialAction.Unbirth))
                 {
                     PounceButtons[currentButton].GetComponentInChildren<Text>().text = $"Too large to {targetedAction.Name}";


### PR DESCRIPTION
 - Adds new menu that allows easily adding empire-wide traits and centralized empire renaming
 - Gnoll breasts no longer clip under clothes or weapons
 - "Vanishe"~~~
 - Upkeep fix
 - Save carryover fix
 - Prevents Ki from pounce CV non-Selicia units
 - Icicle now has a hit check for applying frozen